### PR TITLE
Ticket #18

### DIFF
--- a/balaio/utils.py
+++ b/balaio/utils.py
@@ -191,8 +191,9 @@ def setup_logging():
 def validate_issn(issn):
     """
     This function analyze the ISSN:
-        - Verify the length
         - Verify if it`s a string
+        - Verify the length
+        - Verify the format: ``0102-6720``
         - Return issn if it`s valid
     """
 


### PR DESCRIPTION
Adicionado Pipe para validar o ISSN, objetivo do ISSNPipe:
- Validar o ISSN realizando uma analise do formato e calculando o 'check digit': https://en.wikipedia.org/wiki/International_Standard_Serial_Number;
- Verificar junto ao SciELO Manager a veracidade do dado(AINDA NÃO IMPLEMENTADO);
- Retornar mensagens de status sobre o dado.
