### PR TITLE
Pull request do Issue #55 - ajustes no SetupPipe para deixar disponível os dados do fascículo

### DIFF
--- a/balaio/tests/doubles.py
+++ b/balaio/tests/doubles.py
@@ -37,6 +37,7 @@ class Patch(object):
 class ScieloAPIClientStub(object):
     def __init__(self, *args, **kwargs):
         self.journals = EndpointStub()
+        self.issues = EndpointStub()
 
 
 class EndpointStub(object):
@@ -97,6 +98,8 @@ class ArticlePkgStub(object):
     def __init__(self, *args, **kwargs):
         self.journal_pissn = '0100-879X'
         self.journal_eissn = '0100-879X'
+        self.issue_volume = '1'
+        self.issue_number = '1'
 
 
 class AttemptStub(object):

--- a/balaio/tests/doubles.py
+++ b/balaio/tests/doubles.py
@@ -39,6 +39,10 @@ class ScieloAPIClientStub(object):
         self.journals = EndpointStub()
         self.issues = EndpointStub()
 
+        def fetch_relations(dataset):
+            return dataset
+        self.fetch_relations = fetch_relations
+
 
 class EndpointStub(object):
 

--- a/balaio/tests/test_validator.py
+++ b/balaio/tests/test_validator.py
@@ -349,9 +349,9 @@ class JournalAbbreviatedTitleValidationTests(mocker.MockerTestCase):
 
         self.mocker.replay()
 
-        journal_data = {'short_title': u'An. Acad. Bras. Ciênc.'}
+        journal_and_issue_data = {'journal': {'short_title': u'An. Acad. Bras. Ciênc.'}}
 
-        data = (stub_attempt, stub_package_analyzer, journal_data, {})
+        data = (stub_attempt, stub_package_analyzer, journal_and_issue_data)
 
         vpipe = self._makeOne(data, _pkg_analyzer=stub_package_analyzer)
         vpipe._normalize_data = mock_normalize_data
@@ -376,9 +376,9 @@ class JournalAbbreviatedTitleValidationTests(mocker.MockerTestCase):
 
         self.mocker.replay()
 
-        journal_data = {'short_title': u'An. Acad. Bras. Ciênc.'}
+        journal_and_issue_data = {'journal': {'short_title': u'An. Acad. Bras. Ciênc.'}}
 
-        data = (stub_attempt, stub_package_analyzer, journal_data, {})
+        data = (stub_attempt, stub_package_analyzer, journal_and_issue_data)
 
         vpipe = self._makeOne(data, _pkg_analyzer=stub_package_analyzer)
         vpipe._normalize_data = mock_normalize_data
@@ -394,10 +394,10 @@ class JournalAbbreviatedTitleValidationTests(mocker.MockerTestCase):
         stub_attempt = AttemptStub()
         stub_package_analyzer = self._makePkgAnalyzerWithData(xml)
 
-        journal_data = {}
-        issue_data = {}
+        journal_and_issue_data = {'journal': {}}
+        
 
-        data = (stub_attempt, stub_package_analyzer, journal_data, {})
+        data = (stub_attempt, stub_package_analyzer, journal_and_issue_data)
 
         vpipe = self._makeOne(data, _pkg_analyzer=stub_package_analyzer)
         self.assertEqual(expected,
@@ -411,9 +411,9 @@ class JournalAbbreviatedTitleValidationTests(mocker.MockerTestCase):
         stub_attempt = AttemptStub()
         stub_package_analyzer = self._makePkgAnalyzerWithData(xml)
 
-        journal_data = {'short_title': u'An. Acad. Bras. Ciênc.'}
+        journal_and_issue_data = {'journal': {'short_title': u'An. Acad. Bras. Ciênc.'}}
 
-        data = (stub_attempt, stub_package_analyzer, journal_data, {})
+        data = (stub_attempt, stub_package_analyzer, journal_and_issue_data)
 
         vpipe = self._makeOne(data, _pkg_analyzer=stub_package_analyzer)
         self.assertEqual(expected,
@@ -460,9 +460,9 @@ class PublisherNameValidationPipeTests(mocker.MockerTestCase):
 
         self.mocker.replay()
 
-        journal_data = {'publisher_name': 'publicador da revista brasileira de ....'}
+        journal_and_issue_data = {'journal': {'publisher_name': 'publicador da revista brasileira de ....'}}
 
-        data = (stub_attempt, stub_package_analyzer, journal_data, {})
+        data = (stub_attempt, stub_package_analyzer, journal_and_issue_data)
 
         vpipe = self._makeOne(data, _pkg_analyzer=stub_package_analyzer)
         vpipe._normalize_data = mock_normalize_data
@@ -485,9 +485,9 @@ class PublisherNameValidationPipeTests(mocker.MockerTestCase):
 
         self.mocker.replay()
 
-        journal_data = {'publisher_name': 'publicador da revista brasileira de ....'}
+        journal_and_issue_data = {'journal': {'publisher_name': 'publicador da revista brasileira de ....'}}
 
-        data = (stub_attempt, stub_package_analyzer, journal_data, {})
+        data = (stub_attempt, stub_package_analyzer, journal_and_issue_data)
 
         vpipe = self._makeOne(data, _pkg_analyzer=stub_package_analyzer)
         vpipe._normalize_data = mock_normalize_data
@@ -501,10 +501,10 @@ class PublisherNameValidationPipeTests(mocker.MockerTestCase):
         stub_attempt = AttemptStub()
         stub_package_analyzer = self._makePkgAnalyzerWithData(xml)
 
-        journal_data = {}
-        issue_data = {}
+        journal_and_issue_data = {'journal': {}}
+        
 
-        data = (stub_attempt, stub_package_analyzer, journal_data, {})
+        data = (stub_attempt, stub_package_analyzer, journal_and_issue_data)
 
         vpipe = self._makeOne(data, _pkg_analyzer=stub_package_analyzer)
         self.assertEqual(expected,
@@ -517,9 +517,9 @@ class PublisherNameValidationPipeTests(mocker.MockerTestCase):
         stub_attempt = AttemptStub()
         stub_package_analyzer = self._makePkgAnalyzerWithData(xml)
 
-        journal_data = {'publisher_name': 'publicador da revista brasileira de ....'}
+        journal_and_issue_data = {'journal': {'publisher_name': 'publicador da revista brasileira de ....'}}
 
-        data = (stub_attempt, stub_package_analyzer, journal_data, {})
+        data = (stub_attempt, stub_package_analyzer, journal_and_issue_data)
 
         vpipe = self._makeOne(data, _pkg_analyzer=stub_package_analyzer)
         self.assertEqual(expected,
@@ -547,7 +547,7 @@ class FundingGroupValidationPipeTests(mocker.MockerTestCase):
         xml = '<root></root>'
 
         stub_package_analyzer = self._makePkgAnalyzerWithData(xml)
-        data = (AttemptStub(), stub_package_analyzer, {}, {})
+        data = (AttemptStub(), stub_package_analyzer, {})
 
         vpipe = self._makeOne(xml)
 
@@ -560,7 +560,7 @@ class FundingGroupValidationPipeTests(mocker.MockerTestCase):
 
         stub_attempt = AttemptStub()
         stub_package_analyzer = self._makePkgAnalyzerWithData(xml)
-        data = (stub_attempt, stub_package_analyzer, {}, {})
+        data = (stub_attempt, stub_package_analyzer, {})
 
         vpipe = self._makeOne(xml)
 
@@ -573,7 +573,7 @@ class FundingGroupValidationPipeTests(mocker.MockerTestCase):
 
         stub_attempt = AttemptStub()
         stub_package_analyzer = self._makePkgAnalyzerWithData(xml)
-        data = (stub_attempt, stub_package_analyzer, {}, {})
+        data = (stub_attempt, stub_package_analyzer, {})
 
         vpipe = self._makeOne(xml)
 
@@ -586,7 +586,7 @@ class FundingGroupValidationPipeTests(mocker.MockerTestCase):
 
         stub_attempt = AttemptStub()
         stub_package_analyzer = self._makePkgAnalyzerWithData(xml)
-        data = (stub_attempt, stub_package_analyzer, {}, {})
+        data = (stub_attempt, stub_package_analyzer, {})
 
         vpipe = self._makeOne(xml)
 
@@ -633,9 +633,9 @@ class NLMJournalTitleValidationPipeTests(mocker.MockerTestCase):
 
         self.mocker.replay()
 
-        journal_data = {'medline_title': 'NLM Journal title'}
+        journal_and_issue_data = {'journal': {'medline_title': 'NLM Journal title'}}
 
-        data = (stub_attempt, stub_package_analyzer, journal_data, {})
+        data = (stub_attempt, stub_package_analyzer, journal_and_issue_data)
 
         vpipe = self._makeOne(data, _pkg_analyzer=stub_package_analyzer)
         vpipe._normalize_data = mock_normalize_data
@@ -659,9 +659,9 @@ class NLMJournalTitleValidationPipeTests(mocker.MockerTestCase):
 
         self.mocker.replay()
 
-        journal_data = {'medline_title': 'NLM Journal Title ....'}
+        journal_and_issue_data = {'journal': {'medline_title': 'NLM Journal Title ....'}}
 
-        data = (stub_attempt, stub_package_analyzer, journal_data, {})
+        data = (stub_attempt, stub_package_analyzer, journal_and_issue_data)
 
         vpipe = self._makeOne(data, _pkg_analyzer=stub_package_analyzer)
         vpipe._normalize_data = mock_normalize_data
@@ -676,9 +676,9 @@ class NLMJournalTitleValidationPipeTests(mocker.MockerTestCase):
         stub_attempt = AttemptStub()
         stub_package_analyzer = self._makePkgAnalyzerWithData(xml)
 
-        journal_data = {}
+        journal_and_issue_data = {'journal': {}}
 
-        data = (stub_attempt, stub_package_analyzer, journal_data, {})
+        data = (stub_attempt, stub_package_analyzer, journal_and_issue_data)
 
         vpipe = self._makeOne(data, _pkg_analyzer=stub_package_analyzer)
         self.assertEqual(expected,
@@ -691,14 +691,13 @@ class NLMJournalTitleValidationPipeTests(mocker.MockerTestCase):
         stub_attempt = AttemptStub()
         stub_package_analyzer = self._makePkgAnalyzerWithData(xml)
 
-        journal_data = {'medline_title': 'NLM Journal Title ....'}
+        journal_and_issue_data = {'journal': {'medline_title': 'NLM Journal Title ....'}}
 
-        data = (stub_attempt, stub_package_analyzer, journal_data, {})
+        data = (stub_attempt, stub_package_analyzer, journal_and_issue_data)
 
         vpipe = self._makeOne(data, _pkg_analyzer=stub_package_analyzer)
         self.assertEqual(expected,
                          vpipe.validate(data))
-
 
 
 class DOIVAlidationPipeTests(mocker.MockerTestCase):
@@ -730,28 +729,12 @@ class DOIVAlidationPipeTests(mocker.MockerTestCase):
 
         self.mocker.replay()
 
-        journal_data = {'doi': u'10.1590/S0001-37652013000100008'}
+        #journal_and_issue_data = {'journal': {'doi': u'10.1590/S0001-37652013000100008'}}
 
-        data = (stub_attempt, stub_package_analyzer, journal_data)
+        data = (stub_attempt, stub_package_analyzer, {})
 
         vpipe = self._makeOne(data, _pkg_analyzer=stub_package_analyzer)
         vpipe._doi_validator = mock_doi_validator
-
-        self.assertEqual(expected,
-                         vpipe.validate(data))
-
-    def test_valid_and_unmatched_DOI(self):
-        expected = [validator.STATUS_ERROR, 'the DOI in xml is defferent from the DOI in the source']
-        xml = '<root><article-id pub-id-type="doi">10.1590/S0001-37652013000100007</article-id></root>'
-
-        stub_attempt = AttemptStub()
-        stub_package_analyzer = self._makePkgAnalyzerWithData(xml)
-
-        journal_data = {'doi': u'10.1590/S0001-37652013000100008'}
-
-        data = (stub_attempt, stub_package_analyzer, journal_data)
-
-        vpipe = self._makeOne(data, _pkg_analyzer=stub_package_analyzer)
 
         self.assertEqual(expected,
                          vpipe.validate(data))
@@ -769,9 +752,9 @@ class DOIVAlidationPipeTests(mocker.MockerTestCase):
 
         self.mocker.replay()
 
-        journal_data = {'doi': u'10.1590/S0001-37652013000100002'}
+        #journal_and_issue_data = {'journal': {'doi': u'10.1590/S0001-37652013000100002'}}
 
-        data = (stub_attempt, stub_package_analyzer, journal_data)
+        data = (stub_attempt, stub_package_analyzer, {})
 
         vpipe = self._makeOne(data, _pkg_analyzer=stub_package_analyzer)
         vpipe._doi_validator = mock_doi_validator
@@ -786,9 +769,9 @@ class DOIVAlidationPipeTests(mocker.MockerTestCase):
         stub_attempt = AttemptStub()
         stub_package_analyzer = self._makePkgAnalyzerWithData(xml)
 
-        journal_data = {'doi': u'10.1590/S0001-37652013000100002'}
+        #journal_and_issue_data = {'journal': {'doi': u'10.1590/S0001-37652013000100002'}}
 
-        data = (stub_attempt, stub_package_analyzer, journal_data)
+        data = (stub_attempt, stub_package_analyzer, {})
 
         vpipe = self._makeOne(data, _pkg_analyzer=stub_package_analyzer)
 

--- a/balaio/tests/test_validator.py
+++ b/balaio/tests/test_validator.py
@@ -50,7 +50,7 @@ class SetupPipeTests(mocker.MockerTestCase):
         data = "<root><issn pub-type='epub'>0102-6720</issn></root>"
 
         scieloapi = ScieloAPIClientStub()
-        scieloapi.issues.filter = lambda journal__print_issn=None, journal__eletronic_issn=None, journal=None, volume=None, number=None, suppl_volume=None, suppl_number=None, limit=None: [{}]
+        scieloapi.issues.filter = lambda print_issn=None, eletronic_issn=None, journal=None, volume=None, number=None, suppl_volume=None, suppl_number=None, limit=None: [{}]
 
         vpipe = self._makeOne(data, _scieloapi=scieloapi)
 
@@ -141,7 +141,7 @@ class SetupPipeTests(mocker.MockerTestCase):
         scieloapi.issues.filter = lambda **kwargs: [{'foo': 'bar'}]
 
         vpipe = self._makeOne(data, _scieloapi=scieloapi)
-        self.assertEqual(vpipe._fetch_journal_and_issue_data({'journal__print_issn': '0100-879X', 'volume': '30', 'number': '4'}),
+        self.assertEqual(vpipe._fetch_journal_and_issue_data({'print_issn': '0100-879X', 'volume': '30', 'number': '4'}),
                          {'foo': 'bar'})
 
     def test_transform_grants_valid_issn_before_fetching(self):
@@ -162,7 +162,7 @@ class SetupPipeTests(mocker.MockerTestCase):
             #mock_fetch_journal_data({'print_issn': '0100-879X'})
             #self.mocker.result({'foo': 'bar', 'resource_uri': '/api/...'})
 
-            mock_fetch_journal_and_issue_data({'journal__print_issn': '0100-879X', 'volume': '30', 'number': '4'})
+            mock_fetch_journal_and_issue_data({'print_issn': '0100-879X', 'volume': '30', 'number': '4'})
             self.mocker.result({'foo': 'bar'})
 
             self.mocker.replay()

--- a/balaio/validator.py
+++ b/balaio/validator.py
@@ -30,7 +30,7 @@ class SetupPipe(vpipes.ConfigMixin, vpipes.Pipe):
         """
         found_journals = self._scieloapi.journals.filter(
             limit=1, **criteria)
-        return self._scieloapi.fetch_relations(self._sapi_tools.get_one(found_journals))
+        return self._sapi_tools.get_one(found_journals)
 
     def _fetch_journal_issue_data(self, criteria):
         """
@@ -39,7 +39,7 @@ class SetupPipe(vpipes.ConfigMixin, vpipes.Pipe):
         """
         found_journal_issues = self._scieloapi.issues.filter(
             limit=1, **criteria)
-        return self._sapi_tools.get_one(found_journal_issues)
+        return self._scieloapi.fetch_relations(self._sapi_tools.get_one(found_journal_issues))
 
     def transform(self, attempt):
         """

--- a/balaio/validator.py
+++ b/balaio/validator.py
@@ -70,19 +70,19 @@ class SetupPipe(vpipes.ConfigMixin, vpipes.Pipe):
         journal_pissn = attempt.articlepkg.journal_pissn
 
         if journal_pissn and self._issn_validator(journal_pissn):
-            criteria['journal__print_issn'] = journal_pissn
+            criteria['print_issn'] = journal_pissn
             try:
                 journal_and_issue_data = self._fetch_journal_and_issue_data(
                     criteria)
             except ValueError:
                 # unknown pissn
                 journal_and_issue_data = None
-                del criteria['journal__print_issn']
+                del criteria['print_issn']
 
         journal_eissn = attempt.articlepkg.journal_eissn
         if journal_eissn and self._issn_validator(journal_eissn) and not journal_and_issue_data:
 
-            criteria['journal__eletronic_issn'] = journal_eissn
+            criteria['eletronic_issn'] = journal_eissn
             try:
                 journal_and_issue_data = self._fetch_journal_and_issue_data(
                     criteria)

--- a/balaio/validator.py
+++ b/balaio/validator.py
@@ -30,7 +30,7 @@ class SetupPipe(vpipes.ConfigMixin, vpipes.Pipe):
         """
         found_journals = self._scieloapi.journals.filter(
             limit=1, **criteria)
-        return self._sapi_tools.get_one(found_journals)
+        return self._scieloapi.fetch_relations(self._sapi_tools.get_one(found_journals))
 
     def _fetch_journal_issue_data(self, criteria):
         """
@@ -122,7 +122,7 @@ class PublisherNameValidationPipe(vpipes.ValidationPipe):
         Performs a validation to one `item` of data iterator.
 
         `item` is a tuple comprised of instances of models.Attempt, a
-        checkin.PackageAnalyzer and a dict of journal data.
+        checkin.PackageAnalyzer, a dict of journal data and a dict of issue.
         """
 
         attempt, package_analyzer, journal_data, issue_data = item
@@ -280,7 +280,6 @@ class NLMJournalTitleValidationPipe(vpipes.ValidationPipe):
             else:
                 status, description = [STATUS_ERROR, 'Missing .//journal-meta/journal-id[@journal-id-type="nlm-ta"] in article']
         return [status, description]
-
 
 
 if __name__ == '__main__':

--- a/balaio/validator.py
+++ b/balaio/validator.py
@@ -49,7 +49,7 @@ class SetupPipe(vpipes.ConfigMixin, vpipes.Pipe):
         workflow.
 
         :param attempt: is an models.Attempt instance.
-        :returns: a tuple (Attempt, PackageAnalyzer, journal_data, issue_data)
+        :returns: a tuple (Attempt, PackageAnalyzer, journal_and_issue_data)
         """
         logger.debug('%s started processing %s' % (self.__class__.__name__, attempt))
 
@@ -72,29 +72,29 @@ class SetupPipe(vpipes.ConfigMixin, vpipes.Pipe):
         if journal_pissn and self._issn_validator(journal_pissn):
             criteria['journal__print_issn'] = journal_pissn
             try:
-                journal_data = self._fetch_journal_and_issue_data(
+                journal_and_issue_data = self._fetch_journal_and_issue_data(
                     criteria)
             except ValueError:
                 # unknown pissn
-                journal_data = None
+                journal_and_issue_data = None
                 del criteria['journal__print_issn']
 
         journal_eissn = attempt.articlepkg.journal_eissn
-        if journal_eissn and self._issn_validator(journal_eissn) and not journal_data:
+        if journal_eissn and self._issn_validator(journal_eissn) and not journal_and_issue_data:
 
             criteria['journal__eletronic_issn'] = journal_eissn
             try:
-                journal_data = self._fetch_journal_and_issue_data(
+                journal_and_issue_data = self._fetch_journal_and_issue_data(
                     criteria)
             except ValueError:
                 # unknown eissn
-                journal_data = None
+                journal_and_issue_data = None
 
-        if not journal_data:
+        if not journal_and_issue_data:
             logger.info('%s is not related to a known journal' % attempt)
             attempt.is_valid = False
 
-        return_value = (attempt, pkg_analyzer, journal_data)
+        return_value = (attempt, pkg_analyzer, journal_and_issue_data)
         logger.debug('%s returning %s' % (self.__class__.__name__, ','.join([repr(val) for val in return_value])))
         return return_value
 
@@ -104,7 +104,7 @@ class TearDownPipe(vpipes.ConfigMixin, vpipes.Pipe):
 
     def transform(self, item):
         logger.debug('%s started processing %s' % (self.__class__.__name__, item))
-        attempt, pkg_analyzer, journal_data, issue_data = item
+        attempt, pkg_analyzer, journal_and_issue_data = item
 
         pkg_analyzer.restore_perms()
 
@@ -130,10 +130,10 @@ class PublisherNameValidationPipe(vpipes.ValidationPipe):
         checkin.PackageAnalyzer, a dict of journal data and a dict of issue.
         """
 
-        attempt, package_analyzer, journal_data, issue_data = item
-        j_publisher_name = journal_data.get('publisher_name', None)
+        attempt, pkg_analyzer, journal_and_issue_data = item
+        j_publisher_name = journal_and_issue_data.get('journal').get('publisher_name', None)
         if j_publisher_name:
-            data = package_analyzer.xml
+            data = pkg_analyzer.xml
             xml_publisher_name = data.findtext('.//publisher-name')
 
             if xml_publisher_name:
@@ -186,8 +186,8 @@ class JournalAbbreviatedTitleValidationPipe(vpipes.ValidationPipe):
 
     def validate(self, item):
 
-        attempt, pkg_analyzer, journal_data, issue_data = item
-        abbrev_title = journal_data.get('short_title')
+        attempt, pkg_analyzer, journal_and_issue_data = item
+        abbrev_title = journal_and_issue_data.get('journal').get('short_title')
 
         if abbrev_title:
             abbrev_title_xml = pkg_analyzer.xml.find('.//journal-meta/abbrev-journal-title[@abbrev-type="publisher"]')
@@ -230,7 +230,7 @@ class FundingGroupValidationPipe(vpipes.ValidationPipe):
             """
             return any((True for n in xrange(10) if str(n) in text))
 
-        attempt, pkg_analyzer, journal_data, issue_data = item
+        attempt, pkg_analyzer, journal_and_issue_data = item
 
         xml_tree = pkg_analyzer.xml
 
@@ -268,9 +268,9 @@ class NLMJournalTitleValidationPipe(vpipes.ValidationPipe):
         :returns: [STATUS_OK, ''], if journal has no nlm-journal-title
         :returns: [STATUS_ERROR, nlm-journal-title in article and in journal], if nlm-journal-title in article and journal do not match.
         """
-        attempt, pkg_analyzer, journal_data, issue_data = item
+        attempt, pkg_analyzer, journal_and_issue_data = item
 
-        j_nlm_title = journal_data.get('medline_title', '')
+        j_nlm_title = journal_and_issue_data.get('journal').get('medline_title', '')
         if j_nlm_title == '':
             status, description = [STATUS_OK, 'journal has no NLM journal title']
         else:
@@ -302,15 +302,10 @@ class DOIVAlidationPipe(vpipes.ValidationPipe):
         doi_xml = pkg_analyzer.xml.find('.//article-id/[@pub-id-type="doi"]')
 
         if doi_xml is not None:
-            doi = journal_data.get('doi')
-
-            if doi == doi_xml.text:
-                if self._doi_validator(doi):
-                    return [STATUS_OK, '']
-                else:
-                    return [STATUS_WARNING, 'DOI is not valid']
+            if self._doi_validator(doi_xml.text):
+                return [STATUS_OK, '']
             else:
-                return [STATUS_ERROR, 'the DOI in xml is defferent from the DOI in the source']
+                return [STATUS_WARNING, 'DOI is not valid']
         else:
             return [STATUS_WARNING, 'missing DOI in xml']
 

--- a/balaio/vpipes.py
+++ b/balaio/vpipes.py
@@ -62,7 +62,7 @@ class ValidationPipe(ConfigMixin, plumber.Pipe):
         Performs a transformation to one `item` of data iterator.
 
         `item` is a tuple comprised of instances of models.Attempt, a
-        checkin.PackageAnalyzer and a dict of journal data.
+        checkin.PackageAnalyzer, a dict of journal data and a dict of issue data
         """
         logger.debug('%s started processing %s' % (self.__class__.__name__, item[0]))
 


### PR DESCRIPTION
Da mesma forma que o journal_data contém os dados do journal (provenientes do scieloapi), foi feito o mesmo para o fascículo.
