### PR TITLE
Tk26 refactoring

### DIFF
--- a/balaio/tests/test_validator.py
+++ b/balaio/tests/test_validator.py
@@ -192,7 +192,7 @@ class JournalReferenceTypeValidationPipeTests(unittest.TestCase):
             vpipe.validate(pkg_analyzer_stub), expected)
 
     def test_invalid_content_on_reference_list(self):
-        expected = [validator.STATUS_ERROR, 'missing content on reference tags: source, article-title or year']
+        expected = [validator.STATUS_ERROR, 'There is some erros in refs: (ref_id=B23, error_message=missing content in tag year ) ']
         data = '''
             <root>
               <ref-list>
@@ -225,7 +225,7 @@ class JournalReferenceTypeValidationPipeTests(unittest.TestCase):
             vpipe.validate(pkg_analyzer_stub), expected)
 
     def test_reference_list_missing_any_tag(self):
-        expected = [validator.STATUS_ERROR, 'missing some tag in reference list']
+        expected = [validator.STATUS_ERROR, 'There is some erros in refs: (ref_id=B23, error_message=missing tag article-title ) ']
         data = '''
             <root>
               <ref-list>

--- a/balaio/validator.py
+++ b/balaio/validator.py
@@ -247,15 +247,6 @@ class FundingGroupValidationPipe(vpipes.ValidationPipe):
         return [status, description]
 
 
-class DOIVAlidationPipe(vpipes.ValidationPipe):
-    """
-    Verify if exists DOI in XML and if it`s validated before the CrossRef
-    """
-
-    def configure(self, item):
-        pass
-
-
 if __name__ == '__main__':
     utils.setup_logging()
     config = utils.Configuration.from_env()


### PR DESCRIPTION
Refatorado a validação das referências para o tipo journal.

Essa refatoração visa:
1. Identificar as referências com erro;
2. Validar existência das tags `source`, `article-title` e `year`;
3. Melhorias na mensagem de status da avaliação, informando todos os erros encontrados.
