### PR TITLE
Tk26 - Refactoring

### DIFF
--- a/balaio/tests/test_validator.py
+++ b/balaio/tests/test_validator.py
@@ -143,22 +143,66 @@ class JournalReferenceTypeValidationPipeTests(unittest.TestCase):
               <ref-list>
                 <ref id="B23">
                   <element-citation publication-type="journal">
-                    <person-group person-group-type="author">
-                      <name>
-                        <surname><![CDATA[Winkler]]></surname>
-                        <given-names><![CDATA[JD]]></given-names>
-                      </name>
-                      <name>
-                        <surname><![CDATA[Sánchez-Villagra]]></surname>
-                        <given-names><![CDATA[MR]]></given-names>
-                      </name>
-                    </person-group>
                     <article-title xml:lang="en"><![CDATA[A nesting site and egg morphology of a Miocene turtle from Urumaco, Venezuela: evidence of marine adaptations in Pelomedusoides]]></article-title>
                     <source><![CDATA[Palaeontology]]></source>
                     <year>2013</year>
                     <volume>49</volume>
                     <page-range>641-46</page-range>
                   </element-citation>
+                </ref>
+              </ref-list>
+            </root>'''
+
+        vpipe = self._makeOne(data)
+        pkg_analyzer_stub = self._makePkgAnalyzerWithData(data)
+
+        self.assertEquals(
+            vpipe.validate(pkg_analyzer_stub), expected)
+
+    def test_valid_reference_list_with_two_refs(self):
+        expected = [validator.STATUS_OK, '']
+        data = '''
+            <root>
+              <ref-list>
+                <ref id="B23">
+                  <element-citation publication-type="journal">
+                    <article-title xml:lang="en"><![CDATA[A nesting site and egg morphology of a Miocene turtle from Urumaco, Venezuela: evidence of marine adaptations in Pelomedusoides]]></article-title>
+                    <source><![CDATA[Palaeontology]]></source>
+                    <year>2013</year>
+                  </element-citation>
+                </ref>
+                <ref id="B24">
+                  <element-citation publication-type="journal">
+                    <article-title xml:lang="en"><![CDATA[Title]]></article-title>
+                    <source><![CDATA[Palaeontology]]></source>
+                    <year>2013</year>
+                  </element-citation>
+                </ref>
+              </ref-list>
+            </root>'''
+
+        vpipe = self._makeOne(data)
+        pkg_analyzer_stub = self._makePkgAnalyzerWithData(data)
+
+        self.assertEquals(
+            vpipe.validate(pkg_analyzer_stub), expected)
+
+    def test_valid_reference_list_but_one_without_element_citation(self):
+        expected = [validator.STATUS_OK, '']
+        data = '''
+            <root>
+              <ref-list>
+                <ref id="B23">
+                  <element-citation publication-type="journal">
+                    <article-title xml:lang="en"><![CDATA[A nesting site and egg morphology of a Miocene turtle from Urumaco, Venezuela: evidence of marine adaptations in Pelomedusoides]]></article-title>
+                    <source><![CDATA[Palaeontology]]></source>
+                    <year>2013</year>
+                  </element-citation>
+                </ref>
+                <ref id="B24">
+                  <article-title xml:lang="en"><![CDATA[Title]]></article-title>
+                  <source><![CDATA[Palaeontology]]></source>
+                  <year>2013</year>
                 </ref>
               </ref-list>
             </root>'''
@@ -198,16 +242,6 @@ class JournalReferenceTypeValidationPipeTests(unittest.TestCase):
               <ref-list>
                 <ref id="B23">
                   <element-citation publication-type="journal">
-                    <person-group person-group-type="author">
-                      <name>
-                        <surname><![CDATA[Winkler]]></surname>
-                        <given-names><![CDATA[JD]]></given-names>
-                      </name>
-                      <name>
-                        <surname><![CDATA[Sánchez-Villagra]]></surname>
-                        <given-names><![CDATA[MR]]></given-names>
-                      </name>
-                    </person-group>
                     <article-title xml:lang="en"><![CDATA[A nesting site and egg morphology of a Miocene turtle from Urumaco, Venezuela: evidence of marine adaptations in Pelomedusoides]]></article-title>
                     <source><![CDATA[Palaeontology]]></source>
                     <year></year>
@@ -224,26 +258,106 @@ class JournalReferenceTypeValidationPipeTests(unittest.TestCase):
         self.assertEquals(
             vpipe.validate(pkg_analyzer_stub), expected)
 
-    def test_reference_list_missing_any_tag(self):
+    def test_reference_list_missing_tag_article_title(self):
         expected = [validator.STATUS_ERROR, 'There is some erros in refs: (ref_id=B23, error_message=missing tag article-title ) ']
         data = '''
             <root>
               <ref-list>
                 <ref id="B23">
                   <element-citation publication-type="journal">
-                    <person-group person-group-type="author">
-                      <name>
-                        <surname><![CDATA[Winkler]]></surname>
-                        <given-names><![CDATA[JD]]></given-names>
-                      </name>
-                      <name>
-                        <surname><![CDATA[Sánchez-Villagra]]></surname>
-                        <given-names><![CDATA[MR]]></given-names>
-                      </name>
-                    </person-group>
                     <source><![CDATA[Palaeontology]]></source>
                     <year>2013</year>
                     <volume>49</volume>
+                    <page-range>641-46</page-range>
+                  </element-citation>
+                </ref>
+              </ref-list>
+            </root>'''
+
+        vpipe = self._makeOne(data)
+        pkg_analyzer_stub = self._makePkgAnalyzerWithData(data)
+
+        self.assertEquals(
+            vpipe.validate(pkg_analyzer_stub), expected)
+
+    def test_reference_list_missing_tag_source(self):
+        expected = [validator.STATUS_ERROR, 'There is some erros in refs: (ref_id=B23, error_message=missing tag source ) ']
+        data = '''
+            <root>
+              <ref-list>
+                <ref id="B23">
+                  <element-citation publication-type="journal">
+                    <article-title xml:lang="en"><![CDATA[Title]]></article-title>
+                    <year>2013</year>
+                    <volume>49</volume>
+                    <page-range>641-46</page-range>
+                  </element-citation>
+                </ref>
+              </ref-list>
+            </root>'''
+
+        vpipe = self._makeOne(data)
+        pkg_analyzer_stub = self._makePkgAnalyzerWithData(data)
+
+        self.assertEquals(
+            vpipe.validate(pkg_analyzer_stub), expected)
+
+    def test_reference_list_missing_year(self):
+        expected = [validator.STATUS_ERROR, 'There is some erros in refs: (ref_id=B23, error_message=missing tag year ) ']
+        data = '''
+            <root>
+              <ref-list>
+                <ref id="B23">
+                  <element-citation publication-type="journal">
+                    <article-title xml:lang="en"><![CDATA[Title]]></article-title>
+                    <source><![CDATA[Palaeontology]]></source>
+                    <volume>49</volume>
+                    <page-range>641-46</page-range>
+                  </element-citation>
+                </ref>
+              </ref-list>
+            </root>'''
+
+        vpipe = self._makeOne(data)
+        pkg_analyzer_stub = self._makePkgAnalyzerWithData(data)
+
+        self.assertEquals(
+            vpipe.validate(pkg_analyzer_stub), expected)
+
+    def test_reference_list_missing_content_in_year(self):
+        expected = [validator.STATUS_ERROR, 'There is some erros in refs: (ref_id=B23, error_message=missing content in tag year ) ']
+        data = '''
+            <root>
+              <ref-list>
+                <ref id="B23">
+                  <element-citation publication-type="journal">
+                    <article-title xml:lang="en"><![CDATA[Title]]></article-title>
+                    <source><![CDATA[Palaeontology]]></source>
+                    <volume>49</volume>
+                    <year></year>
+                    <page-range>641-46</page-range>
+                  </element-citation>
+                </ref>
+              </ref-list>
+            </root>'''
+
+        vpipe = self._makeOne(data)
+        pkg_analyzer_stub = self._makePkgAnalyzerWithData(data)
+
+        self.assertEquals(
+            vpipe.validate(pkg_analyzer_stub), expected)
+
+    def test_reference_list_missing_content_in_source(self):
+        expected = [validator.STATUS_ERROR, 'There is some erros in refs: (ref_id=B23, error_message=missing content in tag source ) ']
+        data = '''
+            <root>
+              <ref-list>
+                <ref id="B23">
+                  <element-citation publication-type="journal">
+                    <article-title xml:lang="en"><![CDATA[Title]]></article-title>
+                    <source></source>
+                    <volume>49</volume>
+                    <year>2014</year>
                     <page-range>641-46</page-range>
                   </element-citation>
                 </ref>
@@ -639,7 +753,6 @@ class NLMJournalTitleValidationPipeTests(mocker.MockerTestCase):
         vpipe = self._makeOne(data, _pkg_analyzer=stub_package_analyzer)
         self.assertEqual(expected,
                          vpipe.validate(data))
-
 
 
 class DOIVAlidationPipeTests(mocker.MockerTestCase):

--- a/balaio/tests/test_validator.py
+++ b/balaio/tests/test_validator.py
@@ -192,7 +192,7 @@ class JournalReferenceTypeValidationPipeTests(unittest.TestCase):
             vpipe.validate(pkg_analyzer_stub), expected)
 
     def test_invalid_content_on_reference_list(self):
-        expected = [validator.STATUS_ERROR, 'missing content on reference tags: source, article-title or year']
+        expected = [validator.STATUS_ERROR, 'There is some erros in refs: (ref_id=B23, error_message=missing content in tag year ) ']
         data = '''
             <root>
               <ref-list>
@@ -225,7 +225,7 @@ class JournalReferenceTypeValidationPipeTests(unittest.TestCase):
             vpipe.validate(pkg_analyzer_stub), expected)
 
     def test_reference_list_missing_any_tag(self):
-        expected = [validator.STATUS_ERROR, 'missing some tag in reference list']
+        expected = [validator.STATUS_ERROR, 'There is some erros in refs: (ref_id=B23, error_message=missing tag article-title ) ']
         data = '''
             <root>
               <ref-list>

--- a/balaio/tests/test_validator.py
+++ b/balaio/tests/test_validator.py
@@ -210,20 +210,6 @@ class ReferenceSourceValidationTests(unittest.TestCase):
         self.assertEquals(
             vpipe.validate(pkg_analyzer_stub), expected)
 
-    def test_reference_list_without_ref_list(self):
-        expected = [validator.STATUS_WARNING, 'this xml does not have reference list']
-        data = '''
-            <root>
-              <ref-list>
-              </ref-list>
-            </root>'''
-
-        vpipe = self._makeOne(data)
-        pkg_analyzer_stub = self._makePkgAnalyzerWithData(data)
-
-        self.assertEquals(
-            vpipe.validate(pkg_analyzer_stub), expected)
-
     def test_reference_list_with_tag_source_missing_content(self):
         expected = [validator.STATUS_ERROR, 'There is some errors in refs: B23: missing content in tag source']
         data = '''
@@ -329,20 +315,6 @@ class ReferenceArticleTitleValidationTests(unittest.TestCase):
                     <page-range>641-46</page-range>
                   </element-citation>
                 </ref>
-              </ref-list>
-            </root>'''
-
-        vpipe = self._makeOne(data)
-        pkg_analyzer_stub = self._makePkgAnalyzerWithData(data)
-
-        self.assertEquals(
-            vpipe.validate(pkg_analyzer_stub), expected)
-
-    def test_reference_list_without_ref_list(self):
-        expected = [validator.STATUS_WARNING, 'this xml does not have reference list']
-        data = '''
-            <root>
-              <ref-list>
               </ref-list>
             </root>'''
 
@@ -501,20 +473,6 @@ class ReferenceDateValidationTests(unittest.TestCase):
                     <page-range>641-46</page-range>
                   </element-citation>
                 </ref>
-              </ref-list>
-            </root>'''
-
-        vpipe = self._makeOne(data)
-        pkg_analyzer_stub = self._makePkgAnalyzerWithData(data)
-
-        self.assertEquals(
-            vpipe.validate(pkg_analyzer_stub), expected)
-
-    def test_reference_list_without_ref_list(self):
-        expected = [validator.STATUS_WARNING, 'this xml does not have reference list']
-        data = '''
-            <root>
-              <ref-list>
               </ref-list>
             </root>'''
 

--- a/balaio/tests/test_validator.py
+++ b/balaio/tests/test_validator.py
@@ -119,10 +119,10 @@ class SetupPipeTests(mocker.MockerTestCase):
         result = vpipe.transform(stub_attempt)
 
 
-class JournalReferenceTypeValidationPipeTests(unittest.TestCase):
+class ReferenceSourceValidationTests(unittest.TestCase):
 
     def _makeOne(self, data, **kwargs):
-        vpipe = validator.JournalReferenceTypeValidationPipe(data)
+        vpipe = validator.ReferenceSourceValidationPipe(data)
 
         _pkg_analyzer = kwargs.get('_pkg_analyzer', PackageAnalyzerStub)
         _notifier = kwargs.get('_notifier', NotifierStub())
@@ -136,137 +136,15 @@ class JournalReferenceTypeValidationPipeTests(unittest.TestCase):
         pkg_analyzer_stub._xml_string = data
         return pkg_analyzer_stub
 
-    def test_valid_reference_list(self):
+    def test_reference_list_with_valid_tag_source(self):
         expected = [validator.STATUS_OK, '']
         data = '''
             <root>
               <ref-list>
                 <ref id="B23">
-                  <element-citation publication-type="journal">
-                    <article-title xml:lang="en"><![CDATA[A nesting site and egg morphology of a Miocene turtle from Urumaco, Venezuela: evidence of marine adaptations in Pelomedusoides]]></article-title>
-                    <source><![CDATA[Palaeontology]]></source>
-                    <year>2013</year>
-                    <volume>49</volume>
-                    <page-range>641-46</page-range>
-                  </element-citation>
-                </ref>
-              </ref-list>
-            </root>'''
-
-        vpipe = self._makeOne(data)
-        pkg_analyzer_stub = self._makePkgAnalyzerWithData(data)
-
-        self.assertEquals(
-            vpipe.validate(pkg_analyzer_stub), expected)
-
-    def test_valid_reference_list_with_two_refs(self):
-        expected = [validator.STATUS_OK, '']
-        data = '''
-            <root>
-              <ref-list>
-                <ref id="B23">
-                  <element-citation publication-type="journal">
-                    <article-title xml:lang="en"><![CDATA[A nesting site and egg morphology of a Miocene turtle from Urumaco, Venezuela: evidence of marine adaptations in Pelomedusoides]]></article-title>
-                    <source><![CDATA[Palaeontology]]></source>
-                    <year>2013</year>
-                  </element-citation>
-                </ref>
-                <ref id="B24">
                   <element-citation publication-type="journal">
                     <article-title xml:lang="en"><![CDATA[Title]]></article-title>
                     <source><![CDATA[Palaeontology]]></source>
-                    <year>2013</year>
-                  </element-citation>
-                </ref>
-              </ref-list>
-            </root>'''
-
-        vpipe = self._makeOne(data)
-        pkg_analyzer_stub = self._makePkgAnalyzerWithData(data)
-
-        self.assertEquals(
-            vpipe.validate(pkg_analyzer_stub), expected)
-
-    def test_valid_reference_list_but_one_without_element_citation(self):
-        expected = [validator.STATUS_OK, '']
-        data = '''
-            <root>
-              <ref-list>
-                <ref id="B23">
-                  <element-citation publication-type="journal">
-                    <article-title xml:lang="en"><![CDATA[A nesting site and egg morphology of a Miocene turtle from Urumaco, Venezuela: evidence of marine adaptations in Pelomedusoides]]></article-title>
-                    <source><![CDATA[Palaeontology]]></source>
-                    <year>2013</year>
-                  </element-citation>
-                </ref>
-                <ref id="B24">
-                  <article-title xml:lang="en"><![CDATA[Title]]></article-title>
-                  <source><![CDATA[Palaeontology]]></source>
-                  <year>2013</year>
-                </ref>
-              </ref-list>
-            </root>'''
-
-        vpipe = self._makeOne(data)
-        pkg_analyzer_stub = self._makePkgAnalyzerWithData(data)
-
-        self.assertEquals(
-            vpipe.validate(pkg_analyzer_stub), expected)
-
-    def test_valid_without_reference_list(self):
-        expected = [validator.STATUS_WARNING, 'this xml does not have reference list']
-        data = '''
-            <root>
-              <journal-meta>
-                <journal-id>0001-3765</journal-id>
-                <journal-title><![CDATA[Anais da Academia Brasileira de Ciências]]></journal-title>
-                <abbrev-journal-title><![CDATA[An. Acad. Bras. Ciênc.]]></abbrev-journal-title>
-                <issn>0001-3765</issn>
-                <publisher>
-                  <publisher-name><![CDATA[Academia Brasileira de Ciências]]></publisher-name>
-                </publisher>
-              </journal-meta>
-              <ref-list></ref-list>
-            </root>'''
-
-        vpipe = self._makeOne(data)
-        pkg_analyzer_stub = self._makePkgAnalyzerWithData(data)
-
-        self.assertEquals(
-            vpipe.validate(pkg_analyzer_stub), expected)
-
-    def test_invalid_content_on_reference_list(self):
-        expected = [validator.STATUS_ERROR, 'There is some erros in refs: (ref_id=B23, error_message=missing content in tag year ) ']
-        data = '''
-            <root>
-              <ref-list>
-                <ref id="B23">
-                  <element-citation publication-type="journal">
-                    <article-title xml:lang="en"><![CDATA[A nesting site and egg morphology of a Miocene turtle from Urumaco, Venezuela: evidence of marine adaptations in Pelomedusoides]]></article-title>
-                    <source><![CDATA[Palaeontology]]></source>
-                    <year></year>
-                    <volume>49</volume>
-                    <page-range>641-46</page-range>
-                  </element-citation>
-                </ref>
-              </ref-list>
-            </root>'''
-
-        vpipe = self._makeOne(data)
-        pkg_analyzer_stub = self._makePkgAnalyzerWithData(data)
-
-        self.assertEquals(
-            vpipe.validate(pkg_analyzer_stub), expected)
-
-    def test_reference_list_missing_tag_article_title(self):
-        expected = [validator.STATUS_ERROR, 'There is some erros in refs: (ref_id=B23, error_message=missing tag article-title ) ']
-        data = '''
-            <root>
-              <ref-list>
-                <ref id="B23">
-                  <element-citation publication-type="journal">
-                    <source><![CDATA[Palaeontology]]></source>
-                    <year>2013</year>
                     <volume>49</volume>
                     <page-range>641-46</page-range>
                   </element-citation>
@@ -281,7 +159,7 @@ class JournalReferenceTypeValidationPipeTests(unittest.TestCase):
             vpipe.validate(pkg_analyzer_stub), expected)
 
     def test_reference_list_missing_tag_source(self):
-        expected = [validator.STATUS_ERROR, 'There is some erros in refs: (ref_id=B23, error_message=missing tag source ) ']
+        expected = [validator.STATUS_ERROR, 'There is some errors in refs: B23: missing tag source']
         data = '''
             <root>
               <ref-list>
@@ -302,15 +180,23 @@ class JournalReferenceTypeValidationPipeTests(unittest.TestCase):
         self.assertEquals(
             vpipe.validate(pkg_analyzer_stub), expected)
 
-    def test_reference_list_missing_year(self):
-        expected = [validator.STATUS_ERROR, 'There is some erros in refs: (ref_id=B23, error_message=missing tag year ) ']
+    def test_reference_list_with_two_missing_tag_source(self):
+        expected = [validator.STATUS_ERROR, 'There is some errors in refs: B23: missing tag source B24: missing tag source']
         data = '''
             <root>
               <ref-list>
                 <ref id="B23">
                   <element-citation publication-type="journal">
                     <article-title xml:lang="en"><![CDATA[Title]]></article-title>
-                    <source><![CDATA[Palaeontology]]></source>
+                    <year>2013</year>
+                    <volume>49</volume>
+                    <page-range>641-46</page-range>
+                  </element-citation>
+                </ref>
+                <ref id="B24">
+                  <element-citation publication-type="journal">
+                    <article-title xml:lang="en"><![CDATA[Title]]></article-title>
+                    <year>2013</year>
                     <volume>49</volume>
                     <page-range>641-46</page-range>
                   </element-citation>
@@ -324,20 +210,11 @@ class JournalReferenceTypeValidationPipeTests(unittest.TestCase):
         self.assertEquals(
             vpipe.validate(pkg_analyzer_stub), expected)
 
-    def test_reference_list_missing_content_in_year(self):
-        expected = [validator.STATUS_ERROR, 'There is some erros in refs: (ref_id=B23, error_message=missing content in tag year ) ']
+    def test_reference_list_without_ref_list(self):
+        expected = [validator.STATUS_WARNING, 'this xml does not have reference list']
         data = '''
             <root>
               <ref-list>
-                <ref id="B23">
-                  <element-citation publication-type="journal">
-                    <article-title xml:lang="en"><![CDATA[Title]]></article-title>
-                    <source><![CDATA[Palaeontology]]></source>
-                    <volume>49</volume>
-                    <year></year>
-                    <page-range>641-46</page-range>
-                  </element-citation>
-                </ref>
               </ref-list>
             </root>'''
 
@@ -347,8 +224,8 @@ class JournalReferenceTypeValidationPipeTests(unittest.TestCase):
         self.assertEquals(
             vpipe.validate(pkg_analyzer_stub), expected)
 
-    def test_reference_list_missing_content_in_source(self):
-        expected = [validator.STATUS_ERROR, 'There is some erros in refs: (ref_id=B23, error_message=missing content in tag source ) ']
+    def test_reference_list_with_tag_source_missing_content(self):
+        expected = [validator.STATUS_ERROR, 'There is some errors in refs: B23: missing content in tag source']
         data = '''
             <root>
               <ref-list>
@@ -357,8 +234,308 @@ class JournalReferenceTypeValidationPipeTests(unittest.TestCase):
                     <article-title xml:lang="en"><![CDATA[Title]]></article-title>
                     <source></source>
                     <volume>49</volume>
-                    <year>2014</year>
                     <page-range>641-46</page-range>
+                  </element-citation>
+                </ref>
+              </ref-list>
+            </root>'''
+
+        vpipe = self._makeOne(data)
+        pkg_analyzer_stub = self._makePkgAnalyzerWithData(data)
+
+        self.assertEquals(
+            vpipe.validate(pkg_analyzer_stub), expected)
+
+
+class ReferenceArticleTitleValidationTests(unittest.TestCase):
+
+    def _makeOne(self, data, **kwargs):
+        vpipe = validator.ReferenceArticleTitleValidationPipe(data)
+
+        _pkg_analyzer = kwargs.get('_pkg_analyzer', PackageAnalyzerStub)
+        _notifier = kwargs.get('_notifier', NotifierStub())
+
+        vpipe.configure(_pkg_analyzer=_pkg_analyzer,
+                        _notifier=_notifier)
+        return vpipe
+
+    def _makePkgAnalyzerWithData(self, data):
+        pkg_analyzer_stub = PackageAnalyzerStub()
+        pkg_analyzer_stub._xml_string = data
+        return pkg_analyzer_stub
+
+    def test_reference_list_with_valid_tag_article_title(self):
+        expected = [validator.STATUS_OK, '']
+        data = '''
+            <root>
+              <ref-list>
+                <ref id="B23">
+                  <element-citation publication-type="journal">
+                    <article-title xml:lang="en"><![CDATA[Title]]></article-title>
+                    <source><![CDATA[Palaeontology]]></source>
+                    <volume>49</volume>
+                    <page-range>641-46</page-range>
+                  </element-citation>
+                </ref>
+              </ref-list>
+            </root>'''
+
+        vpipe = self._makeOne(data)
+        pkg_analyzer_stub = self._makePkgAnalyzerWithData(data)
+
+        self.assertEquals(
+            vpipe.validate(pkg_analyzer_stub), expected)
+
+    def test_reference_list_missing_tag_article_title(self):
+        expected = [validator.STATUS_ERROR, 'There is some errors in refs: B23: missing tag article-title']
+        data = '''
+            <root>
+              <ref-list>
+                <ref id="B23">
+                  <element-citation publication-type="journal">
+                    <year>2013</year>
+                    <volume>49</volume>
+                    <source><![CDATA[Palaeontology]]></source>
+                    <page-range>641-46</page-range>
+                  </element-citation>
+                </ref>
+              </ref-list>
+            </root>'''
+
+        vpipe = self._makeOne(data)
+        pkg_analyzer_stub = self._makePkgAnalyzerWithData(data)
+
+        self.assertEquals(
+            vpipe.validate(pkg_analyzer_stub), expected)
+
+    def test_reference_list_with_two_missing_tag_article_title(self):
+        expected = [validator.STATUS_ERROR, 'There is some errors in refs: B23: missing tag article-title B24: missing tag article-title']
+        data = '''
+            <root>
+              <ref-list>
+                <ref id="B23">
+                  <element-citation publication-type="journal">
+                    <year>2013</year>
+                    <volume>49</volume>
+                    <source><![CDATA[Palaeontology]]></source>
+                    <page-range>641-46</page-range>
+                  </element-citation>
+                </ref>
+                <ref id="B24">
+                  <element-citation publication-type="journal">
+                    <year>2013</year>
+                    <volume>49</volume>
+                    <source><![CDATA[Palaeontology]]></source>
+                    <page-range>641-46</page-range>
+                  </element-citation>
+                </ref>
+              </ref-list>
+            </root>'''
+
+        vpipe = self._makeOne(data)
+        pkg_analyzer_stub = self._makePkgAnalyzerWithData(data)
+
+        self.assertEquals(
+            vpipe.validate(pkg_analyzer_stub), expected)
+
+    def test_reference_list_without_ref_list(self):
+        expected = [validator.STATUS_WARNING, 'this xml does not have reference list']
+        data = '''
+            <root>
+              <ref-list>
+              </ref-list>
+            </root>'''
+
+        vpipe = self._makeOne(data)
+        pkg_analyzer_stub = self._makePkgAnalyzerWithData(data)
+
+        self.assertEquals(
+            vpipe.validate(pkg_analyzer_stub), expected)
+
+    def test_reference_list_with_tag_source_missing_content(self):
+        expected = [validator.STATUS_ERROR, 'There is some errors in refs: B23: missing content in tag article-title']
+        data = '''
+            <root>
+              <ref-list>
+                <ref id="B23">
+                  <element-citation publication-type="journal">
+                    <article-title xml:lang="en"></article-title>
+                    <source><![CDATA[Palaeontology]]></source>
+                    <volume>49</volume>
+                    <page-range>641-46</page-range>
+                  </element-citation>
+                </ref>
+              </ref-list>
+            </root>'''
+
+        vpipe = self._makeOne(data)
+        pkg_analyzer_stub = self._makePkgAnalyzerWithData(data)
+
+        self.assertEquals(
+            vpipe.validate(pkg_analyzer_stub), expected)
+
+
+class ReferenceDateValidationTests(unittest.TestCase):
+
+    def _makeOne(self, data, **kwargs):
+        vpipe = validator.ReferenceYearValidationPipe(data)
+
+        _pkg_analyzer = kwargs.get('_pkg_analyzer', PackageAnalyzerStub)
+        _notifier = kwargs.get('_notifier', NotifierStub())
+
+        vpipe.configure(_pkg_analyzer=_pkg_analyzer,
+                        _notifier=_notifier)
+        return vpipe
+
+    def _makePkgAnalyzerWithData(self, data):
+        pkg_analyzer_stub = PackageAnalyzerStub()
+        pkg_analyzer_stub._xml_string = data
+        return pkg_analyzer_stub
+
+    def test_reference_list_with_valid_tag_year(self):
+        expected = [validator.STATUS_OK, '']
+        data = '''
+            <root>
+              <ref-list>
+                <ref id="B23">
+                  <element-citation publication-type="journal">
+                    <article-title xml:lang="en"><![CDATA[Title]]></article-title>
+                    <source><![CDATA[Palaeontology]]></source>
+                    <volume>49</volume>
+                    <year>2013</year>
+                    <page-range>641-46</page-range>
+                  </element-citation>
+                </ref>
+              </ref-list>
+            </root>'''
+
+        vpipe = self._makeOne(data)
+        pkg_analyzer_stub = self._makePkgAnalyzerWithData(data)
+
+        self.assertEquals(
+            vpipe.validate(pkg_analyzer_stub), expected)
+
+    def test_reference_list_with_valid_and_well_format_tag_year(self):
+        expected = [validator.STATUS_OK, '']
+        data = '''
+            <root>
+              <ref-list>
+                <ref id="B23">
+                  <element-citation publication-type="journal">
+                    <article-title xml:lang="en"><![CDATA[Title]]></article-title>
+                    <source><![CDATA[Palaeontology]]></source>
+                    <volume>49</volume>
+                    <year>2013</year>
+                    <page-range>641-46</page-range>
+                  </element-citation>
+                </ref>
+              </ref-list>
+            </root>'''
+
+        vpipe = self._makeOne(data)
+        pkg_analyzer_stub = self._makePkgAnalyzerWithData(data)
+
+        self.assertEquals(
+            vpipe.validate(pkg_analyzer_stub), expected)
+
+    def test_reference_list_with_valid_and_not_well_format_tag_year(self):
+        expected = [validator.STATUS_ERROR, 'There is some errors in refs: B23: date not well format']
+        data = '''
+            <root>
+              <ref-list>
+                <ref id="B23">
+                  <element-citation publication-type="journal">
+                    <article-title xml:lang="en"><![CDATA[Title]]></article-title>
+                    <source><![CDATA[Palaeontology]]></source>
+                    <volume>49</volume>
+                    <year>13</year>
+                    <page-range>641-46</page-range>
+                  </element-citation>
+                </ref>
+              </ref-list>
+            </root>'''
+
+        vpipe = self._makeOne(data)
+        pkg_analyzer_stub = self._makePkgAnalyzerWithData(data)
+
+        self.assertEquals(
+            vpipe.validate(pkg_analyzer_stub), expected)
+
+    def test_reference_list_missing_tag_year(self):
+        expected = [validator.STATUS_ERROR, 'There is some errors in refs: B23: missing tag year']
+        data = '''
+            <root>
+              <ref-list>
+                <ref id="B23">
+                  <element-citation publication-type="journal">
+                    <volume>49</volume>
+                    <source><![CDATA[Palaeontology]]></source>
+                    <page-range>641-46</page-range>
+                  </element-citation>
+                </ref>
+              </ref-list>
+            </root>'''
+
+        vpipe = self._makeOne(data)
+        pkg_analyzer_stub = self._makePkgAnalyzerWithData(data)
+
+        self.assertEquals(
+            vpipe.validate(pkg_analyzer_stub), expected)
+
+    def test_reference_list_with_two_missing_tag_year(self):
+        expected = [validator.STATUS_ERROR, 'There is some errors in refs: B23: missing tag year B24: missing tag year']
+        data = '''
+            <root>
+              <ref-list>
+                <ref id="B23">
+                  <element-citation publication-type="journal">
+                    <volume>49</volume>
+                    <source><![CDATA[Palaeontology]]></source>
+                    <page-range>641-46</page-range>
+                  </element-citation>
+                </ref>
+                <ref id="B24">
+                  <element-citation publication-type="journal">
+                    <volume>49</volume>
+                    <source><![CDATA[Palaeontology]]></source>
+                    <page-range>641-46</page-range>
+                  </element-citation>
+                </ref>
+              </ref-list>
+            </root>'''
+
+        vpipe = self._makeOne(data)
+        pkg_analyzer_stub = self._makePkgAnalyzerWithData(data)
+
+        self.assertEquals(
+            vpipe.validate(pkg_analyzer_stub), expected)
+
+    def test_reference_list_without_ref_list(self):
+        expected = [validator.STATUS_WARNING, 'this xml does not have reference list']
+        data = '''
+            <root>
+              <ref-list>
+              </ref-list>
+            </root>'''
+
+        vpipe = self._makeOne(data)
+        pkg_analyzer_stub = self._makePkgAnalyzerWithData(data)
+
+        self.assertEquals(
+            vpipe.validate(pkg_analyzer_stub), expected)
+
+    def test_reference_list_with_tag_year_missing_content(self):
+        expected = [validator.STATUS_ERROR, 'There is some errors in refs: B23: missing content in tag year']
+        data = '''
+            <root>
+              <ref-list>
+                <ref id="B23">
+                  <element-citation publication-type="journal">
+                    <article-title xml:lang="en"></article-title>
+                    <source><![CDATA[Palaeontology]]></source>
+                    <volume>49</volume>
+                    <page-range>641-46</page-range>
+                    <year></year>
                   </element-citation>
                 </ref>
               </ref-list>

--- a/balaio/validator.py
+++ b/balaio/validator.py
@@ -384,7 +384,9 @@ if __name__ == '__main__':
                           NLMJournalTitleValidationPipe,
                           FundingGroupValidationPipe,
                           DOIVAlidationPipe,
-                          JournalReferenceTypeValidationPipe,
+                          ReferenceSourceValidationPipe,
+                          ReferenceArticleTitleValidationPipe,
+                          ReferenceYearValidationPipe,
                           TearDownPipe)
 
     # add all dependencies to a registry-ish thing

--- a/balaio/validator.py
+++ b/balaio/validator.py
@@ -135,29 +135,25 @@ class JournalReferenceTypeValidationPipe(vpipes.ValidationPipe):
     def validate(self, package_analyzer):
 
         lst_errors = []
+        analyz_tags = {'source': ('missing content in tag source', 'missing tag source'),
+                       'article-title': ('missing content in tag article-title', 'missing tag article-title'),
+                       'year': ('missing content in tag year', 'missing tag year')}
+
         refs = package_analyzer.xml.findall(".//ref-list/ref")
 
         if refs:
             for ref in refs:
                 element_citation = ref.find(".//element-citation[@publication-type='journal']")
 
-                if element_citation.find('source') is not None:
-                    if element_citation.find('source').text is None:
-                        lst_errors.append((ref.attrib['id'], 'missing content in tag source'))
-                else:
-                    lst_errors.append((ref.attrib['id'], 'missing tag source'))
+                if element_citation is not None:
 
-                if element_citation.find('article-title') is not None:
-                    if element_citation.find('article-title').text is None:
-                        lst_errors.append((ref.attrib['id'], 'missing content in tag article-title'))
-                else:
-                    lst_errors.append((ref.attrib['id'], 'missing tag article-title'))
+                    for tag_key, tag_val in analyz_tags.items():
 
-                if element_citation.find('year') is not None:
-                    if element_citation.find('year').text is None:
-                        lst_errors.append((ref.attrib['id'], 'missing content in tag year'))
-                else:
-                    lst_errors.append((ref.attrib['id'], 'missing tag year'))
+                        if element_citation.find(tag_key) is not None:
+                            if element_citation.find(tag_key).text is None:
+                                lst_errors.append((ref.attrib['id'], tag_val[0]))
+                        else:
+                            lst_errors.append((ref.attrib['id'], tag_val[1]))
         else:
             return [STATUS_WARNING, 'this xml does not have reference list']
 

--- a/balaio/validator.py
+++ b/balaio/validator.py
@@ -148,9 +148,6 @@ class ReferenceSourceValidationPipe(vpipes.ValidationPipe):
                 else:
                     lst_errors.append((ref.attrib['id'], 'missing tag source'))
 
-        else:
-            return [STATUS_WARNING, 'this xml does not have reference list']
-
         if lst_errors:
             msg_error = 'There is some errors in refs:'
 
@@ -185,9 +182,6 @@ class ReferenceArticleTitleValidationPipe(vpipes.ValidationPipe):
                         lst_errors.append((ref.attrib['id'], 'missing content in tag article-title'))
                 else:
                     lst_errors.append((ref.attrib['id'], 'missing tag article-title'))
-
-        else:
-            return [STATUS_WARNING, 'this xml does not have reference list']
 
         if lst_errors:
             msg_error = 'There is some errors in refs:'
@@ -226,9 +220,6 @@ class ReferenceYearValidationPipe(vpipes.ValidationPipe):
                             lst_errors.append((ref.attrib['id'], 'date not well format'))
                 else:
                     lst_errors.append((ref.attrib['id'], 'missing tag year'))
-
-        else:
-            return [STATUS_WARNING, 'this xml does not have reference list']
 
         if lst_errors:
             msg_error = 'There is some errors in refs:'

--- a/balaio/validator.py
+++ b/balaio/validator.py
@@ -247,15 +247,6 @@ class FundingGroupValidationPipe(vpipes.ValidationPipe):
         return [status, description]
 
 
-class DOIVAlidationPipe(vpipes.ValidationPipe):
-    """
-    Verify if exists DOI in XML and if it`s validated before the CrossRef
-    """
-
-    def configure(self, item):
-        pass
-
-
 if __name__ == '__main__':
     utils.setup_logging()
     config = utils.Configuration.from_env()


### PR DESCRIPTION
Removido o PIPE anterior que validava as tags: article-title, source e year, criado PIPEs isolados para cada tag.
