### PR TITLE
Garantido que pacotes com o prefixo _failed_ sejam ignorados

### DIFF
--- a/balaio/monitor.py
+++ b/balaio/monitor.py
@@ -1,4 +1,5 @@
 #coding: utf-8
+import os
 import threading
 import Queue
 import logging
@@ -71,12 +72,16 @@ class EventHandler(pyinotify.ProcessEvent):
         self._do_the_job(event)
 
     def _do_the_job(self, event):
+        """
+        Performs work for all except to ``_failed_`` file.
+        """
         filepath = event.pathname
-        if not zipfile.is_zipfile(filepath):
-            logger.info('Invalid zipfile: %s' % filepath)
-            return None
+        if not os.path.basename(filepath).startswith('_failed_'):
+            if not zipfile.is_zipfile(filepath):
+                logger.info('Invalid zipfile: %s' % filepath)
+                return None
 
-        self.monitor.trigger_event(filepath)
+            self.monitor.trigger_event(filepath)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Assim como colocado nos comentários do #59, não é possível adicionar uma lista para excluir arquivos apenas pastas, portanto para que não tenhamos que monitorar arquivos `_failed_`, foi adicionado uma validação garantindo que antes da avaliação do pacote o mesmo não seja prefixado com `_failed_`

Referente ao Bug: #59
