### PR TITLE
Tk78 - Implementação da nova API de notificações

### DIFF
--- a/balaio/models.py
+++ b/balaio/models.py
@@ -144,9 +144,12 @@ class Checkpoint(Base):
     def is_active(self):
         return bool(self.started_at and self.ended_at is None)
 
-    def tell(self, message, label=None):
+    def tell(self, message, status, label=None):
         if not self.is_active:
             raise RuntimeError('cannot tell thing after end was called')
+
+        if status not in Status:
+            raise ValueError('status must be %s' % ','.join(str(st) for st in Status))
 
         notice = Notice(message=message, label=label)
         self.messages.append(notice)

--- a/balaio/models.py
+++ b/balaio/models.py
@@ -83,12 +83,19 @@ class Point(enum.Enum):
     checkout = 3
 
 
+class Status(enum.Enum):
+    ok = 1
+    warning = 2
+    error = 3
+
+
 class Notice(Base):
     __tablename__ = 'notice'
     id = Column(Integer, primary_key=True)
     when = Column(DateTime(timezone=True))
     label = Column(String)
     message = Column(String, nullable=False)
+    status = Column(String, nullable=False)
     checkpoint_id = Column(Integer, ForeignKey('checkpoint.id'))
 
     def __init__(self, *args, **kwargs):

--- a/balaio/models.py
+++ b/balaio/models.py
@@ -1,6 +1,7 @@
 # coding: utf-8
 import datetime
 
+import enum
 from sqlalchemy import (
     Column,
     Integer,
@@ -8,12 +9,14 @@ from sqlalchemy import (
     DateTime,
     String,
     Boolean,
+    Table,
 )
 from sqlalchemy.orm import (
     relationship,
     backref,
 )
 from sqlalchemy.ext.declarative import declarative_base
+from sqlalchemy.ext.hybrid import hybrid_property
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
 
@@ -28,6 +31,7 @@ def create_engine_from_config(config):
     """
     return create_engine(config.get('app', 'db_dsn'),
                          echo=config.getboolean('app', 'debug'))
+
 
 
 class Attempt(Base):
@@ -69,4 +73,83 @@ class ArticlePkg(Base):
 
     def __repr__(self):
         return "<ArticlePkg('%s, %s')>" % (self.id, self.article_title)
+
+
+##
+# Represents system-wide checkpoints
+##
+class Point(enum.Enum):
+    checkin = 1
+    validation = 2
+    checkout = 3
+
+
+class Notice(Base):
+    __tablename__ = 'notice'
+    id = Column(Integer, primary_key=True)
+    when = Column(DateTime(timezone=True))
+    label = Column(String)
+    message = Column(String, nullable=False)
+    checkpoint_id = Column(Integer, ForeignKey('checkpoint.id'))
+
+    def __init__(self, *args, **kwargs):
+        super(Notice, self).__init__(*args, **kwargs)
+        self.when = datetime.datetime.now()
+
+
+class Checkpoint(Base):
+    __tablename__ = 'checkpoint'
+    id = Column(Integer, primary_key=True)
+    started_at = Column(DateTime(timezone=True))
+    ended_at = Column(DateTime(timezone=True))
+    _point = Column('point', Integer, nullable=False)
+    messages = relationship('Notice',
+                            order_by='Notice.when',
+                            backref=backref('checkpoint'))
+
+    def __init__(self, point):
+        """
+        Represents a time delta of a checkpoint execution.
+
+        i.e. the exact moment a module owns the package handling, until it ends.
+        During this delta, arbitrary number of messages with meaningful data may
+        be recorded.
+
+        :param point: a known checkpoint, represented as :class:`Point`.
+        """
+        if point not in Point:
+            raise ValueError('point must be %s' % ','.join(str(pt) for pt in Point))
+
+        self.point = point
+        self.started_at = self.ended_at = None
+
+    def start(self):
+        if self.started_at is None:
+            self.started_at = datetime.datetime.now()
+
+    def end(self):
+        if self.ended_at is None:
+            if not self.is_active:
+                raise RuntimeError('end cannot be called before start')
+
+            self.ended_at = datetime.datetime.now()
+
+    @property
+    def is_active(self):
+        return bool(self.started_at and self.ended_at is None)
+
+    def tell(self, message, label=None):
+        if not self.is_active:
+            raise RuntimeError('cannot tell thing after end was called')
+
+        notice = Notice(message=message, label=label)
+        self.messages.append(notice)
+
+    @hybrid_property
+    def point(self):
+        return Point(self._point)
+
+    @point.setter
+    def point(self, pt):
+        self._point = pt.value
 

--- a/balaio/models.py
+++ b/balaio/models.py
@@ -151,7 +151,7 @@ class Checkpoint(Base):
         if status not in Status:
             raise ValueError('status must be %s' % ','.join(str(st) for st in Status))
 
-        notice = Notice(message=message, label=label)
+        notice = Notice(message=message, status=status, label=label)
         self.messages.append(notice)
 
     @hybrid_property

--- a/balaio/tests/test_models.py
+++ b/balaio/tests/test_models.py
@@ -79,14 +79,14 @@ class CheckpointTests(unittest.TestCase):
     def test_tell_store_messages(self):
         chk_point = Checkpoint(Point.checkin)
         chk_point.start()
-        chk_point.tell('Foo')
+        chk_point.tell('Foo', Status.ok)
         self.assertEqual(chk_point.messages[0].label, None)
         self.assertEqual(chk_point.messages[0].message, 'Foo')
 
     def test_tell_store_messages_based_on_labels(self):
         chk_point = Checkpoint(Point.checkin)
         chk_point.start()
-        chk_point.tell('Foo', label='zip')
+        chk_point.tell('Foo', Status.ok, label='zip')
         self.assertEqual(chk_point.messages[0].label, 'zip')
         self.assertEqual(chk_point.messages[0].message, 'Foo')
 
@@ -94,7 +94,7 @@ class CheckpointTests(unittest.TestCase):
         chk_point = Checkpoint(Point.checkin)
         chk_point.start()
         chk_point.end()
-        self.assertRaises(RuntimeError, lambda: chk_point.tell('Foo', label='zip'))
+        self.assertRaises(RuntimeError, lambda: chk_point.tell('Foo', Status.ok, label='zip'))
 
 
 class NoticeTests(unittest.TestCase):

--- a/balaio/tests/test_models.py
+++ b/balaio/tests/test_models.py
@@ -82,6 +82,7 @@ class CheckpointTests(unittest.TestCase):
         chk_point.tell('Foo', Status.ok)
         self.assertEqual(chk_point.messages[0].label, None)
         self.assertEqual(chk_point.messages[0].message, 'Foo')
+        self.assertEqual(chk_point.messages[0].status, Status.ok)
 
     def test_tell_store_messages_based_on_labels(self):
         chk_point = Checkpoint(Point.checkin)
@@ -89,6 +90,7 @@ class CheckpointTests(unittest.TestCase):
         chk_point.tell('Foo', Status.ok, label='zip')
         self.assertEqual(chk_point.messages[0].label, 'zip')
         self.assertEqual(chk_point.messages[0].message, 'Foo')
+        self.assertEqual(chk_point.messages[0].status, Status.ok)
 
     def test_tell_raises_RuntimeError_on_inactive_objects(self):
         chk_point = Checkpoint(Point.checkin)

--- a/balaio/tests/test_models.py
+++ b/balaio/tests/test_models.py
@@ -1,0 +1,98 @@
+import unittest
+from datetime import datetime
+
+import enum
+
+from balaio.models import Point, Checkpoint
+
+
+class CheckpointTests(unittest.TestCase):
+
+    def test_type_must_be_known(self):
+        chk_point = Checkpoint(Point.checkin)
+        self.assertIsInstance(chk_point, Checkpoint)
+
+    def test_unknown_type_raises_ValueError(self):
+        class Color(enum.Enum):
+            red = 1
+
+        self.assertRaises(ValueError, lambda: Checkpoint(Color.red))
+
+    def test_non_enum_type_raises_ValueError(self):
+        self.assertRaises(ValueError, lambda: Checkpoint('foo'))
+
+    def test_neutral_initial_state(self):
+        chk_point = Checkpoint(Point.checkin)
+        self.assertEqual(chk_point.started_at, None)
+        self.assertEqual(chk_point.ended_at, None)
+
+    def test_started_at_is_filled_on_start(self):
+        chk_point = Checkpoint(Point.checkin)
+        chk_point.start()
+        self.assertIsInstance(chk_point.started_at, datetime)
+
+    def test_start_is_idempotent(self):
+        chk_point = Checkpoint(Point.checkin)
+        chk_point.start()
+        date1 = chk_point.started_at
+        chk_point.start()
+        date2 = chk_point.started_at
+
+        self.assertEqual(date1, date2)
+
+    def test_ended_at_is_filled_on_end(self):
+        chk_point = Checkpoint(Point.checkin)
+        chk_point.start()
+        chk_point.end()
+
+        self.assertIsInstance(chk_point.ended_at, datetime)
+
+    def test_end_is_idempotent(self):
+        chk_point = Checkpoint(Point.checkin)
+        chk_point.start()
+        chk_point.end()
+        date1 = chk_point.ended_at
+        chk_point.end()
+        date2 = chk_point.ended_at
+
+        self.assertEqual(date1, date2)
+
+    def test_end_before_start_raises_RuntimeError(self):
+        chk_point = Checkpoint(Point.checkin)
+        self.assertRaises(RuntimeError, lambda: chk_point.end())
+
+    def test_is_active_returns_False_on_initial_state(self):
+        chk_point = Checkpoint(Point.checkin)
+        self.assertEqual(chk_point.is_active, False)
+
+    def test_is_active_returns_True_after_start(self):
+        chk_point = Checkpoint(Point.checkin)
+        chk_point.start()
+        self.assertEqual(chk_point.is_active, True)
+
+    def test_is_active_returns_False_after_end(self):
+        chk_point = Checkpoint(Point.checkin)
+        chk_point.start()
+        chk_point.end()
+        self.assertEqual(chk_point.is_active, False)
+
+    def test_tell_store_messages(self):
+        chk_point = Checkpoint(Point.checkin)
+        chk_point.start()
+        chk_point.tell('Foo')
+        self.assertEqual(chk_point.messages[0].label, None)
+        self.assertEqual(chk_point.messages[0].message, 'Foo')
+
+    def test_tell_store_messages_based_on_labels(self):
+        chk_point = Checkpoint(Point.checkin)
+        chk_point.start()
+        chk_point.tell('Foo', label='zip')
+        self.assertEqual(chk_point.messages[0].label, 'zip')
+        self.assertEqual(chk_point.messages[0].message, 'Foo')
+
+    def test_tell_raises_RuntimeError_on_inactive_objects(self):
+        chk_point = Checkpoint(Point.checkin)
+        chk_point.start()
+        chk_point.end()
+        self.assertRaises(RuntimeError, lambda: chk_point.tell('Foo', label='zip'))
+

--- a/balaio/tests/test_models.py
+++ b/balaio/tests/test_models.py
@@ -3,7 +3,7 @@ from datetime import datetime
 
 import enum
 
-from balaio.models import Point, Checkpoint
+from balaio.models import Point, Checkpoint, Status, Notice
 
 
 class CheckpointTests(unittest.TestCase):
@@ -95,4 +95,30 @@ class CheckpointTests(unittest.TestCase):
         chk_point.start()
         chk_point.end()
         self.assertRaises(RuntimeError, lambda: chk_point.tell('Foo', label='zip'))
+
+
+class NoticeTests(unittest.TestCase):
+
+    def test_status_set_enum_values(self):
+        ntc = Notice()
+        ntc.status = Status.ok
+        self.assertEqual(ntc.status, Status.ok)
+
+
+class PointTests(unittest.TestCase):
+
+    def test_required_enums(self):
+        names = [pt.name for pt in Point]
+        self.assertIn('checkin', names)
+        self.assertIn('validation', names)
+        self.assertIn('checkout', names)
+
+
+class StatusTests(unittest.TestCase):
+
+    def test_required_enums(self):
+        names = [st.name for st in Status]
+        self.assertIn('ok', names)
+        self.assertIn('warning', names)
+        self.assertIn('error', names)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 requests
 pyinotify
 sqlalchemy
+enum34
 git+git://github.com/gustavofonseca/plumber.git#egg=plumber
 git+git://github.com/scieloorg/scieloapi.py.git#egg=scieloapi


### PR DESCRIPTION
Nessa implementação básica ainda não estão sendo disparadas as requisições HTTP para o Manager, e sim apenas armazenando todas as atividades localmente.

Exemplo de uso:

``` python
>>> from balaio import models, utils
>>> config = utils.Configuration.from_file('config.ini')
>>> Session = models.Session.configure(bind=models.create_engine_from_config(config))
>>> sess = Session()
>>>
>>> cp = models.Checkpoint(Point.checkin)
>>> cp.start()
>>> cp.tell('Holy crap! This article does not have title!', label='front')
>>> # adicionar em uma sessão
>>> sess.add(cp)
>>> sess.commit()
>>> 
>>> cp.end()
>>> sess.commit()
```
