### PR TITLE
Imports relativos em módulos cujo __name__ == "__main__" não são permitidos

### DIFF
--- a/balaio/monitor.py
+++ b/balaio/monitor.py
@@ -9,8 +9,8 @@ import checkin
 import zipfile
 import pyinotify
 
-from . import utils
-from . import models
+import utils
+import models
 
 
 logger = logging.getLogger('balaio.monitor')

--- a/balaio/validator.py
+++ b/balaio/validator.py
@@ -9,7 +9,6 @@ import scieloapi
 
 import vpipes
 import utils
-import notifier
 import checkin
 import scieloapitoolbelt
 import models
@@ -528,7 +527,7 @@ if __name__ == '__main__':
     messages = utils.recv_messages(sys.stdin, utils.make_digest)
     scieloapi = scieloapi.Client(config.get('manager', 'api_username'),
                                  config.get('manager', 'api_key'))
-    notifier_dep = notifier.Notifier()
+    notifier_dep = None
 
     ppl = vpipes.Pipeline(SetupPipe,
                           PublisherNameValidationPipe,


### PR DESCRIPTION
Essa prática levanta a exceção:

``` python
Traceback (most recent call last):
  ...
ValueError: Attempted relative import in non-package
```
