### PR TITLE
[Não incorporar ainda] Relacionado ao Tk145 - Reforma na função `checkin.get_attempt`

### DIFF
--- a/balaio/checkin.py
+++ b/balaio/checkin.py
@@ -235,7 +235,6 @@ def get_attempt(package):
             attempt = models.Attempt.get_from_package(pkg)
             session.add(attempt)
 
-            savepoint = transaction.savepoint()
             try:
                 article_pkg = models.ArticlePkg.get_or_create_from_package(pkg, session)
                 if article_pkg not in session:
@@ -243,10 +242,8 @@ def get_attempt(package):
 
                 attempt.articlepkg = article_pkg
             except:
-                savepoint.rollback()
-
                 attempt.is_valid = False
-                logging.error('Failed to load an ArticlePkg. The Attempt was invalidated.')
+                logging.error('Failed to load an ArticlePkg for %s.' % package)
 
             transaction.commit()
             return attempt

--- a/balaio/checkin.py
+++ b/balaio/checkin.py
@@ -210,9 +210,9 @@ def get_attempt(package):
     Case 1: Package is valid and has all needed metadata:
             A :class:`models.Attempt` is returned, bound to a :class:`models.ArticlePkg`.
     Case 2: Package is valid and doesn't have all needed metadata:
-            A :class:`models.Attempt` is returned, with :attr:`models.ArticlePkg.is_valid==False`.
+            A :class:`models.Attempt` is returned, with :attr:`models.Attempt.is_valid==False`.
     Case 3: Package is invalid
-            A :class:`models.Attempt` is returned, with :attr:`models.ArticlePkg.is_valid==False`.
+            A :class:`models.Attempt` is returned, with :attr:`models.Attempt.is_valid==False`.
     Case 4: Package is duplicated
             raises :class:`excepts.DuplicatedPackage`.
 
@@ -225,10 +225,10 @@ def get_attempt(package):
     with PackageAnalyzer(package) as pkg:
         try:
             Session = models.Session
-            logging.debug('Binding a new sqlalchemy.engine')
+            logger.debug('Binding a new sqlalchemy.engine')
 
             Session.configure(bind=models.create_engine_from_config(config))
-            logging.debug('Creating a transactional session scope')
+            logger.debug('Creating a transactional session scope')
 
             session = Session()
 
@@ -243,7 +243,7 @@ def get_attempt(package):
                 attempt.articlepkg = article_pkg
             except:
                 attempt.is_valid = False
-                logging.error('Failed to load an ArticlePkg for %s.' % package)
+                logger.error('Failed to load an ArticlePkg for %s.' % package)
 
             transaction.commit()
             return attempt
@@ -268,7 +268,7 @@ def get_attempt(package):
             raise ValueError('Unexpected error! The package analysis for %s was aborted.' % package)
 
         finally:
-            logging.debug('Closing the transactional session scope')
+            logger.debug('Closing the transactional session scope')
             session.close()
 
 

--- a/balaio/checkin.py
+++ b/balaio/checkin.py
@@ -245,22 +245,31 @@ def get_attempt(package):
                 attempt.articlepkg = article_pkg
 
             session.commit()
+
         except IOError:
             session.rollback()
             logger.error('The package %s had been deleted during analysis' % package)
             raise ValueError('The package %s had been deleted during analysis' % package)
+
         except IntegrityError:
             session.rollback()
             logger.error('The package already exists. Aborting.')
             raise excepts.DuplicatedPackage('The package %s already exists. Aborting.' % package)
+
         except:
             exc_type, exc_value, exc_traceback = sys.exc_info()
             import traceback
 
             session.rollback()
+
+            logger.error('----------------')
             logger.error('Unexpected error! The package analysis for %s was aborted. Traceback: %s' % (
                 package, traceback.print_tb(exc_traceback)))
+            logger.error('print_exc: %s' % traceback.print_exc())
+            logger.error('----------------')
+
             raise ValueError('Unexpected error! The package analysis for %s was aborted.' % package)
+
         finally:
             logging.debug('Closing the transactional session scope')
             session.close()

--- a/balaio/checkin.py
+++ b/balaio/checkin.py
@@ -219,7 +219,7 @@ def get_attempt(package):
 
             session = Session()
 
-            attempt = models.Attempt.get_from_package(pkg, session)
+            attempt = models.Attempt.get_from_package(pkg)
             session.add(attempt)
 
             try:

--- a/balaio/checkin.py
+++ b/balaio/checkin.py
@@ -201,6 +201,8 @@ def get_attempt(package):
     Always returns a brand new models.Attempt instance, bound to
     the expected models.ArticlePkg instance.
     - Verify if exist at least one ISSN.
+
+    :param package: filesystem path to a package
     """
     config = utils.Configuration.from_env()
 
@@ -208,58 +210,40 @@ def get_attempt(package):
 
     with PackageAnalyzer(package) as pkg:
         try:
-            pkg_meta = pkg.meta
+            Session = models.Session
+            logging.debug('Binding a new sqlalchemy.engine')
 
-            if pkg.is_valid_package() and (pkg_meta['journal_eissn'] or pkg_meta['journal_pissn']):
-                Session = models.Session
+            Session.configure(bind=models.create_engine_from_config(config))
+            logging.debug('Creating a transactional session scope')
 
-                logging.debug('Binding a new sqlalchemy.engine')
-                Session.configure(bind=models.create_engine_from_config(config))
+            session = Session()
 
-                logging.debug('Creating a transactional session scope')
-                session = Session()
+            attempt = models.Attempt.get_from_package(pkg, session)
+            session.add(attempt)
 
-                try:
-                    logging.debug('Getting a models.ArticlePkg')
-                    try:
-                        article_pkg = session.query(models.ArticlePkg).filter_by(article_title=pkg_meta['article_title']).one()
-                    except MultipleResultsFound as e:
-                        logging.error('Multiple results trying to get a models.ArticlePkg for article_title=%s. %s' % (
-                            pkg_meta['article_title'], e))
-                        raise ValueError('Impossible to find a models.ArticlePkg matching criteria')
-                    except NoResultFound as e:
-                        logging.debug('Creating a new models.ArticlePkg')
-                        article_pkg = models.ArticlePkg(**pkg_meta)
-                        session.add(article_pkg)
+            try:
+                # SAVEPOINT
+                session.begin_nested()
+                article_pkg = models.ArticlePkg.get_or_create_from_package(pkg, session)
+                if article_pkg not in session:
+                    session.add(article_pkg)
 
-                    logger.debug('Trying to generate an Attempt for package with chksum: %s and ArticlePkg: %s' % (
-                        pkg.checksum, repr(article_pkg)))
-                    try:
-                        attempt = models.Attempt(package_checksum=pkg.checksum,
-                                                 articlepkg=article_pkg,
-                                                 filepath=package)
-                        session.add(attempt)
-                        session.commit()
-                        logging.debug('Created %s' % attempt)
+                attempt.articlepkg = article_pkg
+            except:
+                logging.error('The transaction was aborted due to an exception')
+                session.rollback()
+                raise
 
-                    except IntegrityError:
-                        logging.debug('The package had already been analyzed')
-                        raise ValueError('The package had already been analyzed')
-                except:
-                    logging.error('The transaction was aborted due to an exception')
-                    session.rollback()
-                    raise
-                finally:
-                    logging.debug('Closing the transactional session scope')
-                    session.close()
-
-                return attempt
-            else:
-                errors = ', '.join(pkg.errors)
-                logger.debug('Invalid package: %s. Errors: %s' % (package, errors))
-                raise ValueError('the package is not valid: %s' % errors)
-
-        except IOError as e:
+            session.commit()
+        except IOError:
+            session.rollback()
             logger.error('The package %s had been deleted during analysis' % package)
             raise ValueError('The package %s had been deleted during analysis' % package)
+        except:
+            session.rollback()
+            logger.error('Unexpected error! The package analysis for %s was aborted.' % package)
+            raise ValueError('Unexpected error! The package analysis for %s was aborted.' % package)
+        finally:
+            logging.debug('Closing the transactional session scope')
+            session.close()
 

--- a/balaio/excepts.py
+++ b/balaio/excepts.py
@@ -1,0 +1,5 @@
+class DuplicatedPackage(Exception):
+    """
+    Raised when a duplicated package is submitted to checkin.
+    """
+    pass

--- a/balaio/models.py
+++ b/balaio/models.py
@@ -19,6 +19,7 @@ from sqlalchemy.orm import (
     scoped_session,
     sessionmaker,
 )
+from sqlalchemy.orm.exc import MultipleResultsFound, NoResultFound
 from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.ext.hybrid import hybrid_property
 from zope.sqlalchemy import ZopeTransactionExtension

--- a/balaio/models.py
+++ b/balaio/models.py
@@ -1,5 +1,6 @@
 # coding: utf-8
 import datetime
+import logging
 
 import enum
 
@@ -24,6 +25,8 @@ from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.ext.hybrid import hybrid_property
 from zope.sqlalchemy import ZopeTransactionExtension
 
+
+logger = logging.getLogger(__name__)
 
 #Use scoped_session only to web app
 ScopedSession = scoped_session(
@@ -150,12 +153,12 @@ class ArticlePkg(Base):
         try:
             article_pkg = session.query(ArticlePkg).filter_by(article_title=meta['article_title']).one()
         except MultipleResultsFound as e:
-            logging.error('Multiple results trying to get a models.ArticlePkg for article_title=%s. %s' % (
+            logger.error('Multiple results trying to get a models.ArticlePkg for article_title=%s. %s' % (
                 meta['article_title'], e))
 
             raise ValueError('Multiple ArticlePkg for the given criteria')
         except NoResultFound as e:
-            logging.debug('Creating a new models.ArticlePkg')
+            logger.debug('Creating a new models.ArticlePkg')
 
             article_pkg = ArticlePkg(**meta)
 

--- a/balaio/models.py
+++ b/balaio/models.py
@@ -93,7 +93,7 @@ class Attempt(Base):
         """
         attempt = Attempt(package_checksum=package.checksum,
                           is_valid=False,
-                          filepath=package._filepath)
+                          filepath=package._filename)
 
         meta = package.meta
 

--- a/balaio/models.py
+++ b/balaio/models.py
@@ -16,6 +16,7 @@ from sqlalchemy.orm import (
     relationship,
     backref,
 )
+from sqlalchemy.orm.exc import MultipleResultsFound, NoResultFound
 from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.ext.hybrid import hybrid_property
 from sqlalchemy import create_engine, select
@@ -42,11 +43,15 @@ def init_database(engine):
 
 
 class Attempt(Base):
+    """
+    Represents a package detected by the monitor, that can be valid or not.
+    If valid, it is bound to an ArticlePkg.
+    """
     __tablename__ = 'attempt'
 
     id = Column(Integer, primary_key=True)
     package_checksum = Column(String(length=32), unique=True)
-    articlepkg_id = Column(Integer, ForeignKey('articlepkg.id'))
+    articlepkg_id = Column(Integer, ForeignKey('articlepkg.id'), nullable=True)
     started_at = Column(DateTime, nullable=False)
     finished_at = Column(DateTime)
     collection_uri = Column(String)
@@ -60,7 +65,7 @@ class Attempt(Base):
     def __init__(self, *args, **kwargs):
         super(Attempt, self).__init__(*args, **kwargs)
         self.started_at = datetime.datetime.now()
-        self.is_valid = True
+        self.is_valid = kwargs.get('is_valid', True)
 
     def to_dict(self):
         checkpoints = {cp.point.name: cp.to_dict() for cp in self.checkpoint if cp.point is not Point.checkout}
@@ -77,6 +82,25 @@ class Attempt(Base):
 
     def __repr__(self):
         return "<Attempt('%s, %s')>" % (self.id, self.package_checksum)
+
+    @classmethod
+    def get_from_package(cls, package, session):
+        """
+        Get an Attempt for a package.
+
+        :param package: instance of :class:`checkin.ArticlePackage`.
+        :param session: sqlalchemy db session
+        """
+        attempt = Attempt(package_checksum=package.checksum,
+                          is_valid=False,
+                          filepath=package._filepath)
+
+        meta = package.meta
+
+        if package.is_valid_package() and (meta['journal_eissn'] or meta['journal_pissn']):
+            attempt.is_valid = True
+
+        return attempt
 
 
 class ArticlePkg(Base):
@@ -111,6 +135,30 @@ class ArticlePkg(Base):
 
     def __repr__(self):
         return "<ArticlePkg('%s, %s')>" % (self.id, self.article_title)
+
+    @classmethod
+    def get_or_create_from_package(cls, package, session):
+        """
+        Get or create an ArticlePkg for a package.
+
+        :param package: instance of :class:`checkin.ArticlePackage`.
+        :param session: sqlalchemy db session
+        """
+        meta = package.meta
+
+        try:
+            article_pkg = session.query(ArticlePkg).filter_by(article_title=meta['article_title']).one()
+        except MultipleResultsFound as e:
+            logging.error('Multiple results trying to get a models.ArticlePkg for article_title=%s. %s' % (
+                meta['article_title'], e))
+
+            raise ValueError('Multiple ArticlePkg for the given criteria')
+        except NoResultFound as e:
+            logging.debug('Creating a new models.ArticlePkg')
+
+            article_pkg = ArticlePkg(**meta)
+
+        return article_pkg
 
 
 class Comment(Base):
@@ -297,6 +345,6 @@ class Checkpoint(Base):
     def to_dict(self):
         return dict(started_at=str(self.started_at),
                     finished_at=str(self.ended_at),
-                    notices=[n.to_dict() for n in self.messages] 
+                    notices=[n.to_dict() for n in self.messages]
                         )
 

--- a/balaio/models.py
+++ b/balaio/models.py
@@ -66,7 +66,7 @@ class Attempt(Base):
     def __init__(self, *args, **kwargs):
         super(Attempt, self).__init__(*args, **kwargs)
         self.started_at = datetime.datetime.now()
-        self.is_valid = True
+        self.is_valid = kwargs.get('is_valid', True)
 
     def to_dict(self):
         checkpoints = {cp.point.name: cp.to_dict() for cp in self.checkpoint if cp.point is not Point.checkout}

--- a/balaio/models.py
+++ b/balaio/models.py
@@ -22,8 +22,10 @@ from sqlalchemy.ext.hybrid import hybrid_property
 from sqlalchemy import create_engine, select
 from sqlalchemy.orm import sessionmaker
 
+from zope.sqlalchemy import ZopeTransactionExtension
 
-Session = sessionmaker(expire_on_commit=False)
+
+Session = sessionmaker(expire_on_commit=False, extension=ZopeTransactionExtension())
 Base = declarative_base()
 
 

--- a/balaio/models.py
+++ b/balaio/models.py
@@ -84,12 +84,11 @@ class Attempt(Base):
         return "<Attempt('%s, %s')>" % (self.id, self.package_checksum)
 
     @classmethod
-    def get_from_package(cls, package, session):
+    def get_from_package(cls, package):
         """
         Get an Attempt for a package.
 
         :param package: instance of :class:`checkin.ArticlePackage`.
-        :param session: sqlalchemy db session
         """
         attempt = Attempt(package_checksum=package.checksum,
                           is_valid=False,

--- a/balaio/monitor.py
+++ b/balaio/monitor.py
@@ -5,12 +5,13 @@ import Queue
 import logging
 import sys
 
-import checkin
 import zipfile
 import pyinotify
 
 import utils
+import checkin
 import models
+import excepts
 
 
 logger = logging.getLogger('balaio.monitor')
@@ -38,7 +39,7 @@ class Monitor(object):
 
             try:
                 attempt = checkin.get_attempt(filepath)
-            except ValueError as e:
+            except (ValueError, excepts.DuplicatedPackage) as e:
                 try:
                     utils.mark_as_failed(filepath)
                 except OSError as e:

--- a/balaio/notifier.py
+++ b/balaio/notifier.py
@@ -87,7 +87,8 @@ def create_checkpoint_notifier(config, point):
                 models.Checkpoint.attempt == attempt).filter(
                 models.Checkpoint.point == point.value).one()
         except sqlalchemy.orm.exc.NoResultFound:
-            checkpoint = models.Checkpoint(point, attempt=attempt)
+            checkpoint = models.Checkpoint(point)
+            checkpoint.attempt = attempt
         except sqlalchemy.orm.exc.MultipleResultsFound as e:
             #logger.error(e.message)
             pass

--- a/balaio/tests/doubles.py
+++ b/balaio/tests/doubles.py
@@ -71,6 +71,13 @@ class PackageAnalyzerStub(object):
         `_xml_string` needs to be patched.
         """
         self._xml_string = None
+        self.checksum = '5a74db5db860f2f8e3c6a5c64acdbf04'
+        self._filepath = '/tmp/bla.zip'
+        self.meta = {
+            'journal_eissn': '1234-1234',
+            'journal_pissn': '1234-4321',
+            'article_title': 'foo',
+        }
 
     @property
     def xml(self):
@@ -79,6 +86,9 @@ class PackageAnalyzerStub(object):
 
     def lock_package(self):
         return None
+
+    def is_valid_package(self):
+        return True
 
 
 def get_ScieloAPIToolbeltStubModule():

--- a/balaio/tests/doubles.py
+++ b/balaio/tests/doubles.py
@@ -72,7 +72,7 @@ class PackageAnalyzerStub(object):
         """
         self._xml_string = None
         self.checksum = '5a74db5db860f2f8e3c6a5c64acdbf04'
-        self._filepath = '/tmp/bla.zip'
+        self._filename = '/tmp/bla.zip'
         self.meta = {
             'journal_eissn': '1234-1234',
             'journal_pissn': '1234-4321',

--- a/balaio/tests/test_checkin.py
+++ b/balaio/tests/test_checkin.py
@@ -338,21 +338,23 @@ class CheckinTests(unittest.TestCase):
         self.session.add(article2)
         self.session.commit()
 
-        self.assertRaises(ValueError, checkin.get_attempt, 'samples/0042-9686-bwho-91-08-545.zip')
+        attempt = checkin.get_attempt('samples/0042-9686-bwho-91-08-545.zip')
+        self.assertIsInstance(attempt, models.Attempt)
 
     def test_get_attempt_invalid_package_missing_xml(self):
         """
         There are more than one article registered with same article title
         """
         pkg = self._make_test_archive([('texto.txt', b'bla bla')])
-        self.assertRaises(AttributeError, checkin.get_attempt, pkg.name)
+        self.assertRaises(ValueError, checkin.get_attempt, pkg.name)
 
     def test_get_attempt_invalid_package_missing_issn(self):
         """
         Package is invalid because there is no ISSN
         """
         pkg = self._make_test_archive([('texto.xml', b'<root/>')])
-        self.assertRaises(ValueError, checkin.get_attempt, pkg.name)
+        attempt = checkin.get_attempt(pkg.name)
+        self.assertIsInstance(attempt, models.Attempt)
 
     def test_get_attempt_inexisting_package(self):
         """

--- a/balaio/tests/test_checkin.py
+++ b/balaio/tests/test_checkin.py
@@ -4,6 +4,7 @@ from xml.etree.ElementTree import ElementTree
 
 import mocker
 import unittest
+import transaction
 
 from balaio import checkin, models
 
@@ -331,12 +332,12 @@ class CheckinTests(unittest.TestCase):
         pkg = checkin.PackageAnalyzer('samples/0042-9686-bwho-91-08-545.zip')
         article = models.ArticlePkg(**pkg.meta)
         self.session.add(article)
-        self.session.commit()
+        transaction.commit()
 
         article2 = models.ArticlePkg(**pkg.meta)
         article2.journal_title = 'REV'
         self.session.add(article2)
-        self.session.commit()
+        transaction.commit()
 
         attempt = checkin.get_attempt('samples/0042-9686-bwho-91-08-545.zip')
         self.assertIsInstance(attempt, models.Attempt)

--- a/balaio/tests/test_checkin.py
+++ b/balaio/tests/test_checkin.py
@@ -337,7 +337,7 @@ class CheckinTests(unittest.TestCase):
         article2.journal_title = 'REV'
         self.session.add(article2)
         self.session.commit()
-        
+
         self.assertRaises(ValueError, checkin.get_attempt, 'samples/0042-9686-bwho-91-08-545.zip')
 
     def test_get_attempt_invalid_package_missing_xml(self):
@@ -359,3 +359,4 @@ class CheckinTests(unittest.TestCase):
         The package is missing
         """
         self.assertRaises(ValueError, checkin.get_attempt, 'package.zip')
+

--- a/balaio/tests/test_checkin.py
+++ b/balaio/tests/test_checkin.py
@@ -293,14 +293,17 @@ class CheckinTests(unittest.TestCase):
     def setUp(self):
         from sqlalchemy import create_engine
 
-        engine = create_engine('sqlite:///:memory:', echo=False)
+        self.engine = create_engine('sqlite:///:memory:', echo=False)
 
         Session = models.Session
-        Session.configure(bind=engine)
+        Session.configure(bind=self.engine)
         self.session = Session()
 
-        models.Base.metadata.create_all(engine)
-        models.create_engine_from_config = lambda config: engine
+        models.Base.metadata.create_all(self.engine)
+        models.create_engine_from_config = lambda config: self.engine
+
+    def tearDown(self):
+        models.Base.metadata.drop_all(self.engine)
 
     def _make_test_archive(self, arch_data):
         fp = NamedTemporaryFile()

--- a/balaio/tests/test_models.py
+++ b/balaio/tests/test_models.py
@@ -1,9 +1,18 @@
 import unittest
 from datetime import datetime
 
+import mocker
 import enum
 
-from balaio.models import Point, Checkpoint, Status, Notice
+from balaio.models import (
+    Point,
+    Checkpoint,
+    Status,
+    Notice,
+    Attempt,
+    ArticlePkg,
+)
+from . import doubles
 
 
 class CheckpointTests(unittest.TestCase):
@@ -123,4 +132,59 @@ class StatusTests(unittest.TestCase):
         self.assertIn('ok', names)
         self.assertIn('warning', names)
         self.assertIn('error', names)
+
+
+class AttemptTests(mocker.MockerTestCase):
+
+    def test_get_from_package(self):
+        mock_session = self.mocker.mock()
+        self.mocker.replay()
+        pkg_analyzer = doubles.PackageAnalyzerStub()
+
+        attempt = Attempt.get_from_package(pkg_analyzer, mock_session)
+
+        self.assertIsInstance(attempt, Attempt)
+
+    def test_get_from_package_not_valid_for_missing_meta(self):
+        mock_session = self.mocker.mock()
+        self.mocker.replay()
+        pkg_analyzer = doubles.PackageAnalyzerStub()
+        pkg_analyzer.meta = {'journal_eissn': None, 'journal_pissn': None}
+
+        attempt = Attempt.get_from_package(pkg_analyzer, mock_session)
+
+        self.assertFalse(attempt.is_valid)
+
+    def test_get_from_package_not_valid_if_invalid(self):
+        mock_session = self.mocker.mock()
+        self.mocker.replay()
+        pkg_analyzer = doubles.PackageAnalyzerStub()
+        pkg_analyzer.meta = {'journal_eissn': '1234-1234', 'journal_pissn': '4321-1234'}
+        pkg_analyzer.is_valid_package = lambda *args, **kwargs: False
+
+        attempt = Attempt.get_from_package(pkg_analyzer, mock_session)
+
+        self.assertFalse(attempt.is_valid)
+
+
+class ArticlePkgTests(mocker.MockerTestCase):
+
+    def test_get_or_create_from_package(self):
+        mock_session = self.mocker.mock()
+
+        mock_session.query(ArticlePkg)
+        self.mocker.result(mock_session)
+
+        mock_session.filter_by(article_title=mocker.ANY)
+        self.mocker.result(mock_session)
+
+        mock_session.one()
+        self.mocker.result(ArticlePkg())
+
+        self.mocker.replay()
+
+        pkg_analyzer = doubles.PackageAnalyzerStub()
+        article_pkg = ArticlePkg.get_or_create_from_package(pkg_analyzer, mock_session)
+
+        self.assertIsInstance(article_pkg, ArticlePkg)
 

--- a/balaio/tests/test_models.py
+++ b/balaio/tests/test_models.py
@@ -141,7 +141,7 @@ class AttemptTests(mocker.MockerTestCase):
         self.mocker.replay()
         pkg_analyzer = doubles.PackageAnalyzerStub()
 
-        attempt = Attempt.get_from_package(pkg_analyzer, mock_session)
+        attempt = Attempt.get_from_package(pkg_analyzer)
 
         self.assertIsInstance(attempt, Attempt)
 
@@ -151,7 +151,7 @@ class AttemptTests(mocker.MockerTestCase):
         pkg_analyzer = doubles.PackageAnalyzerStub()
         pkg_analyzer.meta = {'journal_eissn': None, 'journal_pissn': None}
 
-        attempt = Attempt.get_from_package(pkg_analyzer, mock_session)
+        attempt = Attempt.get_from_package(pkg_analyzer)
 
         self.assertFalse(attempt.is_valid)
 
@@ -162,7 +162,7 @@ class AttemptTests(mocker.MockerTestCase):
         pkg_analyzer.meta = {'journal_eissn': '1234-1234', 'journal_pissn': '4321-1234'}
         pkg_analyzer.is_valid_package = lambda *args, **kwargs: False
 
-        attempt = Attempt.get_from_package(pkg_analyzer, mock_session)
+        attempt = Attempt.get_from_package(pkg_analyzer)
 
         self.assertFalse(attempt.is_valid)
 

--- a/balaio/utils.py
+++ b/balaio/utils.py
@@ -195,6 +195,10 @@ def mark_as_failed(filename):
     prefix_file(filename, '_failed_')
 
 
+def mark_as_duplicated(filename):
+    prefix_file(filename, '_duplicated_')
+
+
 def setup_logging():
     global has_logger
     # avoid setting up more than once per process

--- a/balaio/validator.py
+++ b/balaio/validator.py
@@ -53,6 +53,7 @@ class SetupPipe(vpipes.Pipe):
             limit=1, **criteria)
         return self._scieloapi.fetch_relations(self._sapi_tools.get_one(found_journal_issues))
 
+    @vpipes.precondition(vpipes.attempt_is_valid)
     def transform(self, attempt):
         """
         Adds some data that will be needed during validation
@@ -114,6 +115,7 @@ class TearDownPipe(vpipes.Pipe):
         self._sapi_tools = sapi_tools
         self._pkg_analyzer = pkg_analyzer
 
+    @vpipes.precondition(vpipes.attempt_is_valid)
     def transform(self, item):
         logger.debug('%s started processing %s' % (self.__class__.__name__, item))
         attempt, pkg_analyzer, journal_and_issue_data = item
@@ -122,11 +124,7 @@ class TearDownPipe(vpipes.Pipe):
 
         pkg_analyzer.restore_perms()
 
-        if attempt.is_valid:
-            logger.info('Finished validating %s' % attempt)
-        else:
-            utils.mark_as_failed(attempt.filepath)
-            logger.info('%s is invalid. Finished.' % attempt)
+        logger.info('Finished validating %s' % attempt)
 
 
 class PublisherNameValidationPipe(vpipes.ValidationPipe):

--- a/balaio/vpipes.py
+++ b/balaio/vpipes.py
@@ -1,11 +1,21 @@
 import logging
 
-from plumber import Pipe, Pipeline
+from plumber import Pipe, Pipeline, precondition, UnmetPrecondition
 
 import scieloapitoolbelt
 
 
 logger = logging.getLogger(__name__)
+
+
+def attempt_is_valid(data):
+    try:
+        attempt, _, __ = data
+    except TypeError:
+        attempt = data
+
+    if attempt.is_valid != True:
+        raise UnmetPrecondition()
 
 
 class ValidationPipe(Pipe):
@@ -18,6 +28,7 @@ class ValidationPipe(Pipe):
         self._scieloapi = scieloapi
         self._sapi_tools = sapi_tools
 
+    @precondition(attempt_is_valid)
     def transform(self, item):
         """
         Performs a transformation to one `item` of data iterator.

--- a/balaio/vpipes.py
+++ b/balaio/vpipes.py
@@ -15,6 +15,7 @@ def attempt_is_valid(data):
         attempt = data
 
     if attempt.is_valid != True:
+        logger.debug('Attempt %s does not comply the precondition to be processed by the pipe. Bypassing.' % repr(attempt))
         raise UnmetPrecondition()
 
 


### PR DESCRIPTION
A função passou a gerar um attempt para representar cada pacote depositado no FTP, seja ele válido ou não. A única exceção é para pacotes repetidos que são renomeados adicionando o prefixo '_duplicated_'. 

Esse PR quebra alguns testes, portanto ainda não deve ser incorporado ainda.
