### PR TITLE
simplifying sections of journal_and_issue_data from scieloapi (#159)

### DIFF
--- a/balaio/scieloapitoolbelt.py
+++ b/balaio/scieloapitoolbelt.py
@@ -38,3 +38,36 @@ def get_one(dataset):
     else:
         raise ValueError('dataset is empty')
 
+
+def section_titles(dataset):
+    """
+    Returns sections titles from dataset
+    dataset[0]['code'] = rsp-01
+    dataset[0]['titles'] = [[pt, Artigos originais],
+                            [es, Artículos originales],
+                            [en, Original articles],
+                            ]
+    dataset[1]['code'] = rsp-02
+    dataset[1]['titles'] = [[pt, Notícias],
+                            [es, Noticias],
+                            [en, News],
+                            ]
+
+    :return: [Artigos originais, Artículos originales, Original articles, ...]
+    """
+    valid_input = False
+    if isinstance(dataset, list):
+        if 'code' in dataset[0].keys() and 'titles' in dataset[0].keys():
+            if isinstance(dataset[0]['titles'], list):
+                if isinstance(dataset[0]['titles'][0], list):
+                    if len(dataset[0]['titles'][0][0]) == 2:
+                        valid_input = True
+    if valid_input:
+        r = []
+        for section in dataset:
+            # section is dict which has code and titles as key
+            for lang, title in section['titles']:
+                # section['titles'] = [[pt, Artigos ...], [es, Artículos], ]
+                r.append(title)
+
+    return r

--- a/balaio/tests/test_scieloapitoolbelt.py
+++ b/balaio/tests/test_scieloapitoolbelt.py
@@ -1,0 +1,35 @@
+# coding: utf-8
+import mocker
+import unittest
+
+from balaio import scieloapitoolbelt
+
+
+class SimplifyIssueSectionsTests(unittest.TestCase):
+
+    def test_section_titles(self):
+        """
+        Symplify the result of scieloapi query like that dataset['sections']
+
+        dataset['sections'][0]['code'] = rsp-01
+        dataset['sections'][0]['titles'] = [[pt, Artigos originais],
+                                [es, Artículos originales],
+                                [en, Original articles],
+                                ]
+        dataset['sections'][1]['code'] = rsp-02
+        dataset['sections'][1]['titles'] = [[pt, Notícias],
+                                [es, Noticias],
+                                [en, News],
+                                ]
+
+        :return: [Artigos originais, Artículos originales, Original articles, ...]
+        """
+        dataset = {'sections': [
+                        {u'code': u'BWHO-hm3b', u'titles': [[u'en', u'News'], [u'es', u'Noticias'], [u'pt', u'Notícias']]},
+                        {u'code': u'BWHO-prtj', u'titles': [[u'en', u'Police & Practice']]},
+                        {u'code': u'BWHO-r9vg', u'titles': [[u'en', u'Research']]},
+                     ]
+            }
+        self.assertEqual(scieloapitoolbelt.section_titles(dataset['sections']),
+                [u'News', u'Noticias', u'Notícias', u'Police & Practice', u'Research']
+            )

--- a/balaio/tests/test_validator.py
+++ b/balaio/tests/test_validator.py
@@ -1087,15 +1087,7 @@ class ArticleSectionValidationPipeTests(mocker.MockerTestCase):
 
     def _issue_data(self):
         # isso deveria ser um dict no lugar de uma lista, mas a api retorna assim
-        dict_item1 = {u'titles': [
-            [u'es', u'Artículos Originales'],
-            [u'en', u'Original Articles'],
-        ]}
-        dict_item2 = {u'titles': [
-            [u'es', u'Editorial'],
-            [u'en', u'Editorial'],
-        ]}
-        return {u'sections': [dict_item1, dict_item2], u'label': '1(1)'}
+        return {u'section titles': [u'Artículos Originales', u'Original Articles', u'Editorial'], u'label': '1(1)'}
 
     def test_article_section_matched(self):
         expected = [models.Status.ok, 'Original Articles']
@@ -1106,7 +1098,7 @@ class ArticleSectionValidationPipeTests(mocker.MockerTestCase):
         stub_package_analyzer = self._makePkgAnalyzerWithData(xml)
 
         mock_is_a_registered_section_title = self.mocker.mock()
-        mock_is_a_registered_section_title(self._issue_data()['sections'], 'Original Articles')
+        mock_is_a_registered_section_title(self._issue_data()['section titles'], 'Original Articles')
         self.mocker.result(True)
 
         self.mocker.replay()
@@ -1119,14 +1111,14 @@ class ArticleSectionValidationPipeTests(mocker.MockerTestCase):
                          vpipe.validate(data))
 
     def test_article_section_is_not_registered(self):
-        expected = [models.Status.error, 'Articles is not registered as section in 1(1)']
+        expected = [models.Status.error, 'Mismatched data: Articles. Expected one of %s' % ' | '.join(self._issue_data()['section titles'])]
         xml = '<root><article-meta><article-categories><subj-group subj-group-type="heading"><subject>Articles</subject></subj-group></article-categories></article-meta></root>'
 
         stub_attempt = AttemptStub()
         stub_package_analyzer = self._makePkgAnalyzerWithData(xml)
 
         mock_is_a_registered_section_title = self.mocker.mock()
-        mock_is_a_registered_section_title(self._issue_data()['sections'], 'Articles')
+        mock_is_a_registered_section_title(self._issue_data()['section titles'], 'Articles')
         self.mocker.result(False)
 
         self.mocker.replay()


### PR DESCRIPTION
Fixes #159

Obs.: esta simplificação ocorre no SetupPipe, no dado (journal_and_issue_data) obtido do resultado de consulta do scieloapi.
