### PR TITLE
Garante que um attempt somente é valido com o título do artigo

### DIFF
--- a/balaio/models.py
+++ b/balaio/models.py
@@ -101,7 +101,7 @@ class Attempt(Base):
                           is_valid=False,
                           filepath=package._filename)
         meta = package.meta
-        if package.is_valid_package() and (meta['journal_eissn'] or meta['journal_pissn']):
+        if package.is_valid_package() and meta['article_title'] and (meta['journal_eissn'] or meta['journal_pissn']):
             attempt.is_valid = True
         return attempt
 

--- a/balaio/tests/test_models.py
+++ b/balaio/tests/test_models.py
@@ -148,7 +148,8 @@ class AttemptTests(mocker.MockerTestCase):
         mock_session = self.mocker.mock()
         self.mocker.replay()
         pkg_analyzer = doubles.PackageAnalyzerStub()
-        pkg_analyzer.meta = {'journal_eissn': None, 'journal_pissn': None}
+        pkg_analyzer.meta = {'journal_eissn': None, 'journal_pissn': None,
+                            'article_title': None}
 
         attempt = Attempt.get_from_package(pkg_analyzer)
         self.assertFalse(attempt.is_valid)


### PR DESCRIPTION
Em testes realizados na minha VM encontrei a situação em que não existia a tag `article-title`, isso fez a aplicação parar de funcionar, esse ajuste garante que seja obrigatório o título do artigo no XML, caso contrário o attempt é marcado como `invalid`
