### PR TITLE
Ajustes nos testes para utilizar Postgres

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,3 +5,5 @@ install:
   - pip install -r requirements.txt --use-mirrors
 script:
   - python setup.py nosetests
+before_script:
+  - psql -c 'create database app_balaio_tests;' -U postgres

--- a/balaio/checkin.py
+++ b/balaio/checkin.py
@@ -282,9 +282,13 @@ def get_attempt(package):
 
         except IntegrityError as e:
             transaction.abort()
-            logger.error('The package already exists. Aborting.')
+            logger.error('The package has no integrity. Aborting.')
             logger.debug('---> Traceback: %s' % e)
-            raise excepts.DuplicatedPackage('The package %s already exists. Aborting.' % package)
+
+            if 'violates not-null constraint' in e.message:
+                raise ValueError('An integrity error was cast as ValueError.')
+            else:
+                raise excepts.DuplicatedPackage('The package %s already exists.' % package)
 
         except Exception as e:
             transaction.abort()

--- a/balaio/models.py
+++ b/balaio/models.py
@@ -149,7 +149,7 @@ class ArticlePkg(Base):
         """
         meta = package.meta
         try:
-            article_pkg = session.query(ArticlePkg).filter_by(**package.criteria).one()
+            article_pkg = session.query(ArticlePkg).filter_by(article_title=meta['article_title']).one()
         except MultipleResultsFound as e:
             logger.error('Multiple results trying to get a models.ArticlePkg for article_title=%s. %s' % (
                 meta['article_title'], e))

--- a/balaio/tests/doubles.py
+++ b/balaio/tests/doubles.py
@@ -292,3 +292,6 @@ class DummyRoutesMapper:
     def get_route(self, route_name):
         return self.route
 
+
+class SessionStub(object):
+    pass

--- a/balaio/tests/modelfactories.py
+++ b/balaio/tests/modelfactories.py
@@ -1,0 +1,43 @@
+import factory
+from factory.alchemy import SQLAlchemyModelFactory
+
+from balaio import models
+
+
+class ArticlePkgFactory(SQLAlchemyModelFactory):
+    FACTORY_FOR = models.ArticlePkg
+    FACTORY_SESSION = models.ScopedSession
+
+    id = factory.Sequence(lambda n: n)
+    article_title = 'Construction of a recombinant adenovirus...'
+    journal_pissn = '0100-879X'
+    journal_eissn = '0100-879X'
+    journal_title = 'Associa... Brasileira'
+    issue_year = 1995
+    issue_volume = '67'
+    issue_number = '8'
+    issue_suppl_volume = None
+    issue_suppl_number = None
+
+
+class AttemptFactory(SQLAlchemyModelFactory):
+    FACTORY_FOR = models.Attempt
+    FACTORY_SESSION = models.ScopedSession
+
+    id = factory.Sequence(lambda n: n)
+    package_checksum = factory.Sequence(lambda n: '20132df0as89dds73as936%s' % n)
+    finished_at = None
+    collection_uri = ''
+    articlepkg = factory.SubFactory(ArticlePkgFactory)
+    filepath = '/tmp/watch/xxx.zip'
+
+
+class TicketFactory(SQLAlchemyModelFactory):
+    FACTORY_FOR = models.Ticket
+    FACTORY_SESSION = models.ScopedSession
+
+    id = factory.Sequence(lambda n: n)
+    title = "Erro no pacote xxx"
+    author = 'Aberlado Barbosa'
+    articlepkg = factory.SubFactory(ArticlePkgFactory)
+

--- a/balaio/tests/test_gateway_server.py
+++ b/balaio/tests/test_gateway_server.py
@@ -336,6 +336,8 @@ class TicketFunctionalAPITest(unittest.TestCase):
 
     def setUp(self):
         self._loaded_fixtures = [self._makeOne() for i in range(3)]
+        models.ScopedSession.flush()
+
         self.config = testing.setUp()
         app = gateway_server.main(ConfigStub(), global_engine)
         self.testapp = TestApp(app)
@@ -348,7 +350,7 @@ class TicketFunctionalAPITest(unittest.TestCase):
         transaction.abort()
         models.ScopedSession.remove()
 
-    def _makeOne(self, id=1):
+    def _makeOne(self):
         import datetime
         ticket = modelfactories.TicketFactory.create()
         ticket.started_at = datetime.datetime(2013, 10, 9, 16, 44, 29, 865787)
@@ -596,7 +598,6 @@ class TicketFunctionalAPITest(unittest.TestCase):
 
     def test_POST_to_create_ticket_without_message(self):
         articlepkg_id = self._loaded_fixtures[0].articlepkg.id
-        models.ScopedSession.flush()  # avoid integrity errors
 
         res = self.testapp.post('/api/v1/tickets/',
                 {
@@ -609,7 +610,6 @@ class TicketFunctionalAPITest(unittest.TestCase):
 
     def test_POST_to_create_ticket_with_message(self):
         articlepkg_id = self._loaded_fixtures[0].articlepkg.id
-        models.ScopedSession.flush()  # avoid integrity errors
 
         res = self.testapp.post('/api/v1/tickets/',
                 {
@@ -622,7 +622,8 @@ class TicketFunctionalAPITest(unittest.TestCase):
         self.assertEqual(res.status_code, 201)
 
     def test_POST_to_update_ticket_with_different_params(self):
-        res_post = self.testapp.post('/api/v1/tickets/3/',
+        ticket_id = self._loaded_fixtures[2].id
+        res_post = self.testapp.post('/api/v1/tickets/%s/' % ticket_id,
                 {
                  'message': 'Error on validation....',
                  'is_open': 1,
@@ -631,7 +632,7 @@ class TicketFunctionalAPITest(unittest.TestCase):
 
         self.assertEqual(res_post.status_code, 202)
 
-        res_get = self.testapp.get('/api/v1/tickets/3/')
+        res_get = self.testapp.get('/api/v1/tickets/%s/' % ticket_id)
 
         res_json = json.loads(res_get.body)
 
@@ -651,53 +652,192 @@ class TicketFunctionalAPITest(unittest.TestCase):
 class PackageFunctionalAPITest(unittest.TestCase):
 
     def setUp(self):
-        _load_fixtures(self._makeList())
+        self._loaded_fixtures = [self._makeOne() for i in range(3)]
+        models.ScopedSession.flush()
+
         self.config = testing.setUp()
         app = gateway_server.main(ConfigStub(), global_engine)
         self.testapp = TestApp(app)
 
     def tearDown(self):
+        transaction.abort()
         models.ScopedSession.remove()
         testing.tearDown()
 
-    def _makeOne(self, id=1):
-        article = models.ArticlePkg(id=id,
-                    journal_title='Associa... Brasileira',
-                    article_title='Construction of a recombinant adenovirus...',
-                    journal_pissn='0100-879X',
-                    journal_eissn='0100-879X',
-                    issue_year=1995,
-                    issue_volume='67',
-                    issue_number='8',
-                    issue_suppl_volume=None,
-                    issue_suppl_number=None)
+    def _makeOne(self):
+        article = modelfactories.ArticlePkgFactory.create()
         return article
-
-    def _makeList(self):
-        return [self._makeOne(), self._makeOne(2), self._makeOne(3)]
 
     def test_GET_to_available_resource(self):
         self.testapp.get('/api/v1/packages/', status=200)
 
     def test_GET_to_one_package(self):
-        res = self.testapp.get('/api/v1/packages/1/')
+        articlepkg_id = self._loaded_fixtures[0].id
 
-        self.assertEqual(json.loads(res.body), json.loads('{"article_title": "Construction of a recombinant adenovirus...", "tickets": [], "issue_year": 1995, "journal_title": "Associa... Brasileira", "journal_pissn": "0100-879X", "journal_eissn": "0100-879X", "issue_suppl_number": null, "attempts": [], "issue_suppl_volume": null, "issue_volume": "67", "resource_uri": "/api/v1/packages/1/", "id": 1, "issue_number": "8"}'))
+        res = self.testapp.get('/api/v1/packages/%s/' % articlepkg_id)
+
+        expected = '''{"article_title": "Construction of a recombinant adenovirus...",
+                       "tickets": [],
+                       "issue_year": 1995,
+                       "journal_title": "Associa... Brasileira",
+                       "journal_pissn": "0100-879X",
+                       "journal_eissn": "0100-879X",
+                       "issue_suppl_number": null,
+                       "attempts": [],
+                       "issue_suppl_volume": null,
+                       "issue_volume": "67",
+                       "resource_uri": "/api/v1/packages/%s/",
+                       "id": %s,
+                       "issue_number": "8"}''' % (articlepkg_id, articlepkg_id)
+
+        self.assertEqual(json.loads(res.body), json.loads(expected))
 
     def test_GET_to_packages(self):
+        articlepkg0_id = self._loaded_fixtures[0].id
+        articlepkg1_id = self._loaded_fixtures[1].id
+        articlepkg2_id = self._loaded_fixtures[2].id
+
         res = self.testapp.get('/api/v1/packages/')
 
-        self.assertEqual(json.loads(res.body), json.loads('{"meta": {"previous": null, "next": null, "total": 3, "limit": 20, "offset": 0}, "objects": [{"article_title": "Construction of a recombinant adenovirus...", "tickets": [], "issue_year": 1995, "journal_title": "Associa... Brasileira", "journal_pissn": "0100-879X", "journal_eissn": "0100-879X", "issue_suppl_number": null, "attempts": [], "issue_suppl_volume": null, "issue_volume": "67", "resource_uri": "/api/v1/packages/1/", "id": 1, "issue_number": "8"}, {"article_title": "Construction of a recombinant adenovirus...", "tickets": [], "issue_year": 1995, "journal_title": "Associa... Brasileira", "journal_pissn": "0100-879X", "journal_eissn": "0100-879X", "issue_suppl_number": null, "attempts": [], "issue_suppl_volume": null, "issue_volume": "67", "resource_uri": "/api/v1/packages/2/", "id": 2, "issue_number": "8"}, {"article_title": "Construction of a recombinant adenovirus...", "tickets": [], "issue_year": 1995, "journal_title": "Associa... Brasileira", "journal_pissn": "0100-879X", "journal_eissn": "0100-879X", "issue_suppl_number": null, "attempts": [], "issue_suppl_volume": null, "issue_volume": "67", "resource_uri": "/api/v1/packages/3/", "id": 3, "issue_number": "8"}]}'))
+        expected = '''{"meta": {"previous": null, "next": null, "total": 3, "limit": 20, "offset": 0},
+                       "objects": [
+                           {"article_title": "Construction of a recombinant adenovirus...",
+                            "tickets": [],
+                            "issue_year": 1995,
+                            "journal_title": "Associa... Brasileira",
+                            "journal_pissn": "0100-879X",
+                            "journal_eissn": "0100-879X",
+                            "issue_suppl_number": null,
+                            "attempts": [],
+                            "issue_suppl_volume": null,
+                            "issue_volume": "67",
+                            "resource_uri": "/api/v1/packages/%s/",
+                            "id": %s,
+                            "issue_number": "8"},
+                           {"article_title": "Construction of a recombinant adenovirus...",
+                            "tickets": [],
+                            "issue_year": 1995,
+                            "journal_title": "Associa... Brasileira",
+                            "journal_pissn": "0100-879X",
+                            "journal_eissn": "0100-879X",
+                            "issue_suppl_number": null,
+                            "attempts": [],
+                            "issue_suppl_volume": null,
+                            "issue_volume": "67",
+                            "resource_uri": "/api/v1/packages/%s/",
+                            "id": %s,
+                            "issue_number": "8"},
+                           {"article_title": "Construction of a recombinant adenovirus...",
+                            "tickets": [],
+                            "issue_year": 1995,
+                            "journal_title": "Associa... Brasileira",
+                            "journal_pissn": "0100-879X",
+                            "journal_eissn": "0100-879X",
+                            "issue_suppl_number": null,
+                            "attempts": [],
+                            "issue_suppl_volume": null,
+                            "issue_volume": "67",
+                            "resource_uri": "/api/v1/packages/%s/",
+                            "id": %s,
+                            "issue_number": "8"}
+                    ]}''' % (articlepkg0_id, articlepkg0_id,
+                             articlepkg1_id, articlepkg1_id,
+                             articlepkg2_id, articlepkg2_id)
+
+        self.assertEqual(json.loads(res.body), json.loads(expected))
 
     def test_GET_to_packages_with_param_limit(self):
+        articlepkg0_id = self._loaded_fixtures[0].id
+        articlepkg1_id = self._loaded_fixtures[1].id
+        articlepkg2_id = self._loaded_fixtures[2].id
+
         res = self.testapp.get('/api/v1/packages/?limit=82')
 
-        self.assertEqual(json.loads(res.body), json.loads('{"meta": {"previous": null, "next": null, "total": 3, "limit": 82, "offset": 0}, "objects": [{"article_title": "Construction of a recombinant adenovirus...", "tickets": [], "issue_year": 1995, "journal_title": "Associa... Brasileira", "journal_pissn": "0100-879X", "journal_eissn": "0100-879X", "issue_suppl_number": null, "attempts": [], "issue_suppl_volume": null, "issue_volume": "67", "resource_uri": "/api/v1/packages/1/", "id": 1, "issue_number": "8"}, {"article_title": "Construction of a recombinant adenovirus...", "tickets": [], "issue_year": 1995, "journal_title": "Associa... Brasileira", "journal_pissn": "0100-879X", "journal_eissn": "0100-879X", "issue_suppl_number": null, "attempts": [], "issue_suppl_volume": null, "issue_volume": "67", "resource_uri": "/api/v1/packages/2/", "id": 2, "issue_number": "8"}, {"article_title": "Construction of a recombinant adenovirus...", "tickets": [], "issue_year": 1995, "journal_title": "Associa... Brasileira", "journal_pissn": "0100-879X", "journal_eissn": "0100-879X", "issue_suppl_number": null, "attempts": [], "issue_suppl_volume": null, "issue_volume": "67", "resource_uri": "/api/v1/packages/3/", "id": 3, "issue_number": "8"}]}'))
+        expected = '''{"meta": {"previous": null, "next": null, "total": 3, "limit": 82, "offset": 0},
+                       "objects": [
+                           {"article_title": "Construction of a recombinant adenovirus...",
+                            "tickets": [],
+                            "issue_year": 1995,
+                            "journal_title": "Associa... Brasileira",
+                            "journal_pissn": "0100-879X",
+                            "journal_eissn": "0100-879X",
+                            "issue_suppl_number": null,
+                            "attempts": [],
+                            "issue_suppl_volume": null,
+                            "issue_volume": "67",
+                            "resource_uri": "/api/v1/packages/%s/",
+                            "id": %s,
+                            "issue_number": "8"},
+                           {"article_title": "Construction of a recombinant adenovirus...",
+                            "tickets": [],
+                            "issue_year": 1995,
+                            "journal_title": "Associa... Brasileira",
+                            "journal_pissn": "0100-879X",
+                            "journal_eissn": "0100-879X",
+                            "issue_suppl_number": null,
+                            "attempts": [],
+                            "issue_suppl_volume": null,
+                            "issue_volume": "67",
+                            "resource_uri": "/api/v1/packages/%s/",
+                            "id": %s,
+                            "issue_number": "8"},
+                           {"article_title": "Construction of a recombinant adenovirus...",
+                            "tickets": [],
+                            "issue_year": 1995,
+                            "journal_title": "Associa... Brasileira",
+                            "journal_pissn": "0100-879X",
+                            "journal_eissn": "0100-879X",
+                            "issue_suppl_number": null,
+                            "attempts": [],
+                            "issue_suppl_volume": null,
+                            "issue_volume": "67",
+                            "resource_uri": "/api/v1/packages/%s/",
+                            "id": %s,
+                            "issue_number": "8"}
+                    ]}''' % (articlepkg0_id, articlepkg0_id,
+                             articlepkg1_id, articlepkg1_id,
+                             articlepkg2_id, articlepkg2_id)
+
+        self.assertEqual(json.loads(res.body), json.loads(expected))
 
     def test_GET_to_packages_with_param_offset(self):
+        articlepkg1_id = self._loaded_fixtures[1].id
+        articlepkg2_id = self._loaded_fixtures[2].id
+
         res = self.testapp.get('/api/v1/packages/?offset=1')
 
-        self.assertEqual(json.loads(res.body), json.loads('{"meta": {"previous": null, "next": null, "total": 3, "limit": 20, "offset": "1"}, "objects": [{"article_title": "Construction of a recombinant adenovirus...", "tickets": [], "issue_year": 1995, "journal_title": "Associa... Brasileira", "journal_pissn": "0100-879X", "journal_eissn": "0100-879X", "issue_suppl_number": null, "attempts": [], "issue_suppl_volume": null, "issue_volume": "67", "resource_uri": "/api/v1/packages/2/", "id": 2, "issue_number": "8"}, {"article_title": "Construction of a recombinant adenovirus...", "tickets": [], "issue_year": 1995, "journal_title": "Associa... Brasileira", "journal_pissn": "0100-879X", "journal_eissn": "0100-879X", "issue_suppl_number": null, "attempts": [], "issue_suppl_volume": null, "issue_volume": "67", "resource_uri": "/api/v1/packages/3/", "id": 3, "issue_number": "8"}]}'))
+        expected = '''{"meta": {"previous": null, "next": null, "total": 3, "limit": 20, "offset": "1"},
+                       "objects": [
+                           {"article_title": "Construction of a recombinant adenovirus...",
+                            "tickets": [],
+                            "issue_year": 1995,
+                            "journal_title": "Associa... Brasileira",
+                            "journal_pissn": "0100-879X",
+                            "journal_eissn": "0100-879X",
+                            "issue_suppl_number": null,
+                            "attempts": [],
+                            "issue_suppl_volume": null,
+                            "issue_volume": "67",
+                            "resource_uri": "/api/v1/packages/%s/",
+                            "id": %s,
+                            "issue_number": "8"},
+                           {"article_title": "Construction of a recombinant adenovirus...",
+                            "tickets": [],
+                            "issue_year": 1995,
+                            "journal_title": "Associa... Brasileira",
+                            "journal_pissn": "0100-879X",
+                            "journal_eissn": "0100-879X",
+                            "issue_suppl_number": null,
+                            "attempts": [],
+                            "issue_suppl_volume": null,
+                            "issue_volume": "67",
+                            "resource_uri": "/api/v1/packages/%s/",
+                            "id": %s,
+                            "issue_number": "8"}
+                    ]}''' % (articlepkg1_id, articlepkg1_id,
+                             articlepkg2_id, articlepkg2_id)
+
+        self.assertEqual(json.loads(res.body), json.loads(expected))
 
     def test_GET_to_packages_with_param_offset_and_limit(self):
         res = self.testapp.get('/api/v1/packages/?offset=4&limit=78')
@@ -705,19 +845,106 @@ class PackageFunctionalAPITest(unittest.TestCase):
         self.assertEqual(json.loads(res.body), json.loads('{"meta": {"previous": null, "next": null, "total": 3, "limit": 78, "offset": "4"}, "objects": []}'))
 
     def test_GET_to_packages_with_param_low_limit(self):
+        articlepkg0_id = self._loaded_fixtures[0].id
+        articlepkg1_id = self._loaded_fixtures[1].id
+
         res = self.testapp.get('/api/v1/packages/?limit=2')
 
-        self.assertEqual(json.loads(res.body), json.loads('{"meta": {"previous": null, "next": "/api/v1/packages/?limit=2&offset=2", "total": 3, "limit": 2, "offset": 0}, "objects": [{"article_title": "Construction of a recombinant adenovirus...", "tickets": [], "issue_year": 1995, "journal_title": "Associa... Brasileira", "journal_pissn": "0100-879X", "journal_eissn": "0100-879X", "issue_suppl_number": null, "attempts": [], "issue_suppl_volume": null, "issue_volume": "67", "resource_uri": "/api/v1/packages/1/", "id": 1, "issue_number": "8"}, {"article_title": "Construction of a recombinant adenovirus...", "tickets": [], "issue_year": 1995, "journal_title": "Associa... Brasileira", "journal_pissn": "0100-879X", "journal_eissn": "0100-879X", "issue_suppl_number": null, "attempts": [], "issue_suppl_volume": null, "issue_volume": "67", "resource_uri": "/api/v1/packages/2/", "id": 2, "issue_number": "8"}]}'))
+        expected = '''{"meta": {"previous": null, "next": "/api/v1/packages/?limit=2&offset=2", "total": 3, "limit": 2, "offset": 0},
+                       "objects": [
+                           {"article_title": "Construction of a recombinant adenovirus...",
+                            "tickets": [],
+                            "issue_year": 1995,
+                            "journal_title": "Associa... Brasileira",
+                            "journal_pissn": "0100-879X",
+                            "journal_eissn": "0100-879X",
+                            "issue_suppl_number": null,
+                            "attempts": [],
+                            "issue_suppl_volume": null,
+                            "issue_volume": "67",
+                            "resource_uri": "/api/v1/packages/%s/",
+                            "id": %s,
+                            "issue_number": "8"},
+                           {"article_title": "Construction of a recombinant adenovirus...",
+                            "tickets": [],
+                            "issue_year": 1995,
+                            "journal_title": "Associa... Brasileira",
+                            "journal_pissn": "0100-879X",
+                            "journal_eissn": "0100-879X",
+                            "issue_suppl_number": null,
+                            "attempts": [],
+                            "issue_suppl_volume": null,
+                            "issue_volume": "67",
+                            "resource_uri": "/api/v1/packages/%s/",
+                            "id": %s,
+                            "issue_number": "8"}
+                    ]}''' % (articlepkg0_id, articlepkg0_id,
+                             articlepkg1_id, articlepkg1_id)
+
+        self.assertEqual(json.loads(res.body), json.loads(expected))
 
     def test_GET_to_packages_with_param_low_offset_and_limit(self):
+        articlepkg1_id = self._loaded_fixtures[1].id
+        articlepkg2_id = self._loaded_fixtures[2].id
+
         res = self.testapp.get('/api/v1/packages/?limit=2&offset=1')
 
-        self.assertEqual(json.loads(res.body), json.loads('{"meta": {"previous": null, "next": "/api/v1/packages/?limit=2&offset=3", "total": 3, "limit": 2, "offset": "1"}, "objects": [{"article_title": "Construction of a recombinant adenovirus...", "tickets": [], "issue_year": 1995, "journal_title": "Associa... Brasileira", "journal_pissn": "0100-879X", "journal_eissn": "0100-879X", "issue_suppl_number": null, "attempts": [], "issue_suppl_volume": null, "issue_volume": "67", "resource_uri": "/api/v1/packages/2/", "id": 2, "issue_number": "8"}, {"article_title": "Construction of a recombinant adenovirus...", "tickets": [], "issue_year": 1995, "journal_title": "Associa... Brasileira", "journal_pissn": "0100-879X", "journal_eissn": "0100-879X", "issue_suppl_number": null, "attempts": [], "issue_suppl_volume": null, "issue_volume": "67", "resource_uri": "/api/v1/packages/3/", "id": 3, "issue_number": "8"}]}'))
+        expected = '''{"meta": {"previous": null, "next": "/api/v1/packages/?limit=2&offset=3", "total": 3, "limit": 2, "offset": "1"},
+                       "objects": [
+                           {"article_title": "Construction of a recombinant adenovirus...",
+                            "tickets": [],
+                            "issue_year": 1995,
+                            "journal_title": "Associa... Brasileira",
+                            "journal_pissn": "0100-879X",
+                            "journal_eissn": "0100-879X",
+                            "issue_suppl_number": null,
+                            "attempts": [],
+                            "issue_suppl_volume": null,
+                            "issue_volume": "67",
+                            "resource_uri": "/api/v1/packages/%s/",
+                            "id": %s,
+                            "issue_number": "8"},
+                           {"article_title": "Construction of a recombinant adenovirus...",
+                            "tickets": [],
+                            "issue_year": 1995,
+                            "journal_title": "Associa... Brasileira",
+                            "journal_pissn": "0100-879X",
+                            "journal_eissn": "0100-879X",
+                            "issue_suppl_number": null,
+                            "attempts": [],
+                            "issue_suppl_volume": null,
+                            "issue_volume": "67",
+                            "resource_uri": "/api/v1/packages/%s/",
+                            "id": %s,
+                            "issue_number": "8"}
+                    ]}''' % (articlepkg1_id, articlepkg1_id,
+                             articlepkg2_id, articlepkg2_id)
+
+        self.assertEqual(json.loads(res.body), json.loads(expected))
 
     def test_GET_to_packages_with_param_low_limit_and_offset(self):
+        articlepkg2_id = self._loaded_fixtures[2].id
+
         res = self.testapp.get('/api/v1/packages/?limit=1&offset=2')
 
-        self.assertEqual(json.loads(res.body), json.loads('{"meta": {"previous": "/api/v1/packages/?limit=1&offset=1", "next": "/api/v1/packages/?limit=1&offset=3", "total": 3, "limit": 1, "offset": "2"}, "objects": [{"article_title": "Construction of a recombinant adenovirus...", "tickets": [], "issue_year": 1995, "journal_title": "Associa... Brasileira", "journal_pissn": "0100-879X", "journal_eissn": "0100-879X", "issue_suppl_number": null, "attempts": [], "issue_suppl_volume": null, "issue_volume": "67", "resource_uri": "/api/v1/packages/3/", "id": 3, "issue_number": "8"}]}'))
+        expected = '''{"meta": {"previous": "/api/v1/packages/?limit=1&offset=1", "next": "/api/v1/packages/?limit=1&offset=3", "total": 3, "limit": 1, "offset": "2"},
+                       "objects": [
+                           {"article_title": "Construction of a recombinant adenovirus...",
+                            "tickets": [],
+                            "issue_year": 1995,
+                            "journal_title": "Associa... Brasileira",
+                            "journal_pissn": "0100-879X",
+                            "journal_eissn": "0100-879X",
+                            "issue_suppl_number": null,
+                            "attempts": [],
+                            "issue_suppl_volume": null,
+                            "issue_volume": "67",
+                            "resource_uri": "/api/v1/packages/%s/",
+                            "id": %s,
+                            "issue_number": "8"}
+                    ]}''' % (articlepkg2_id, articlepkg2_id)
+
+        self.assertEqual(json.loads(res.body), json.loads(expected))
 
 
 class AttemptsAPITest(unittest.TestCase):

--- a/balaio/tests/test_gateway_server.py
+++ b/balaio/tests/test_gateway_server.py
@@ -27,7 +27,6 @@ def setUpModule():
     global global_engine
     global_engine = db_bootstrap()
 
-
 def _load_fixtures(obj_list):
 
     with transaction.manager:
@@ -342,9 +341,12 @@ class TicketFunctionalAPITest(unittest.TestCase):
         self.testapp = TestApp(app)
 
     def tearDown(self):
+        testing.tearDown()
+        self._clean_session()
+
+    def _clean_session(self):
         transaction.abort()
         models.ScopedSession.remove()
-        testing.tearDown()
 
     def _makeOne(self, id=1):
         import datetime
@@ -419,14 +421,85 @@ class TicketFunctionalAPITest(unittest.TestCase):
         self.assertEqual(json.loads(res.body), json.loads(expected))
 
     def test_GET_to_tickets_with_param_limit(self):
+        ticket0_id = self._loaded_fixtures[0].id
+        articlepkg0_id = self._loaded_fixtures[0].articlepkg.id
+
+        ticket1_id = self._loaded_fixtures[1].id
+        articlepkg1_id = self._loaded_fixtures[1].articlepkg.id
+
+        ticket2_id = self._loaded_fixtures[2].id
+        articlepkg2_id = self._loaded_fixtures[2].articlepkg.id
+
         res = self.testapp.get('/api/v1/tickets/?limit=45')
 
-        self.assertEqual(json.loads(res.body), json.loads('{"meta": {"previous": null, "next": null, "total": 3, "limit": 45, "offset": 0}, "objects": [{"title": "Erro no pacote xxx", "finished_at": null, "author": "Aberlado Barbosa", "articlepkg_id": 1, "comments": [], "is_open": true, "started_at": "2013-10-09 16:44:29.865787", "id": 1, "resource_uri": "/api/v1/tickets/1/"}, {"title": "Erro no pacote xxx", "finished_at": null, "author": "Aberlado Barbosa", "articlepkg_id": 1, "comments": [], "is_open": true, "started_at": "2013-10-09 16:44:29.865787", "id": 2, "resource_uri": "/api/v1/tickets/2/"}, {"title": "Erro no pacote xxx", "finished_at": null, "author": "Aberlado Barbosa", "articlepkg_id": 1, "comments": [], "is_open": true, "started_at": "2013-10-09 16:44:29.865787", "id": 3, "resource_uri": "/api/v1/tickets/3/"}]}'))
+        expected = '''{"meta": {"previous": null, "next": null, "total": 3, "limit": 45, "offset": 0},
+                       "objects": [
+                           {"title": "Erro no pacote xxx",
+                            "finished_at": null,
+                            "author": "Aberlado Barbosa",
+                            "articlepkg_id": %s,
+                            "comments": [],
+                            "is_open": true,
+                            "started_at": "2013-10-09 16:44:29.865787",
+                            "id": %s,
+                            "resource_uri": "/api/v1/tickets/%s/"},
+                           {"title": "Erro no pacote xxx",
+                            "finished_at": null,
+                            "author": "Aberlado Barbosa",
+                            "articlepkg_id": %s,
+                            "comments": [],
+                            "is_open": true,
+                            "started_at": "2013-10-09 16:44:29.865787",
+                            "id": %s,
+                            "resource_uri": "/api/v1/tickets/%s/"},
+                           {"title": "Erro no pacote xxx",
+                            "finished_at": null,
+                            "author": "Aberlado Barbosa",
+                            "articlepkg_id": %s,
+                            "comments": [],
+                            "is_open": true,
+                            "started_at": "2013-10-09 16:44:29.865787",
+                            "id": %s,
+                            "resource_uri": "/api/v1/tickets/%s/"}
+                    ]}''' % (articlepkg0_id, ticket0_id, ticket0_id,
+                             articlepkg1_id, ticket1_id, ticket1_id,
+                             articlepkg2_id, ticket2_id, ticket2_id)
+
+        self.assertEqual(json.loads(res.body), json.loads(expected))
 
     def test_GET_to_tickets_with_param_offset(self):
+        ticket1_id = self._loaded_fixtures[1].id
+        articlepkg1_id = self._loaded_fixtures[1].articlepkg.id
+
+        ticket2_id = self._loaded_fixtures[2].id
+        articlepkg2_id = self._loaded_fixtures[2].articlepkg.id
+
         res = self.testapp.get('/api/v1/tickets/?offset=1')
 
-        self.assertEqual(json.loads(res.body), json.loads('{"meta": {"previous": null, "next": null, "total": 3, "limit": 20, "offset": "1"}, "objects": [{"title": "Erro no pacote xxx", "finished_at": null, "author": "Aberlado Barbosa", "articlepkg_id": 1, "comments": [], "is_open": true, "started_at": "2013-10-09 16:44:29.865787", "id": 2, "resource_uri": "/api/v1/tickets/2/"}, {"title": "Erro no pacote xxx", "finished_at": null, "author": "Aberlado Barbosa", "articlepkg_id": 1, "comments": [], "is_open": true, "started_at": "2013-10-09 16:44:29.865787", "id": 3, "resource_uri": "/api/v1/tickets/3/"}]}'))
+        expected = '''{"meta": {"previous": null, "next": null, "total": 3, "limit": 20, "offset": "1"},
+                       "objects": [
+                          {"title": "Erro no pacote xxx",
+                           "finished_at": null,
+                           "author": "Aberlado Barbosa",
+                           "articlepkg_id": %s,
+                           "comments": [],
+                           "is_open": true,
+                           "started_at": "2013-10-09 16:44:29.865787",
+                           "id": %s,
+                           "resource_uri": "/api/v1/tickets/%s/"},
+                          {"title": "Erro no pacote xxx",
+                           "finished_at": null,
+                           "author": "Aberlado Barbosa",
+                           "articlepkg_id": %s,
+                           "comments": [],
+                           "is_open": true,
+                           "started_at": "2013-10-09 16:44:29.865787",
+                           "id": %s,
+                           "resource_uri": "/api/v1/tickets/%s/"}
+                    ]}''' % (articlepkg1_id, ticket1_id, ticket1_id,
+                             articlepkg2_id, ticket2_id, ticket2_id)
+
+        self.assertEqual(json.loads(res.body), json.loads(expected))
 
     def test_GET_to_tickets_with_param_offset_and_limit(self):
         res = self.testapp.get('/api/v1/tickets/?offset=4&limit=78')
@@ -434,24 +507,100 @@ class TicketFunctionalAPITest(unittest.TestCase):
         self.assertEqual(json.loads(res.body), json.loads('{"meta": {"previous": null, "next": null, "total": 3, "limit": 78, "offset": "4"}, "objects": []}'))
 
     def test_GET_to_tickets_with_param_low_limit(self):
-        res = self.testapp.get('/api/v1/tickets/?limit=2')
+        ticket0_id = self._loaded_fixtures[0].id
+        articlepkg0_id = self._loaded_fixtures[0].articlepkg.id
 
-        self.assertEqual(json.loads(res.body), json.loads('{"meta": {"previous": null, "next": "/api/v1/tickets/?limit=2&offset=2", "total": 3, "limit": 2, "offset": 0}, "objects": [{"title": "Erro no pacote xxx", "finished_at": null, "author": "Aberlado Barbosa", "articlepkg_id": 1, "comments": [], "is_open": true, "started_at": "2013-10-09 16:44:29.865787", "id": 1, "resource_uri": "/api/v1/tickets/1/"}, {"title": "Erro no pacote xxx", "finished_at": null, "author": "Aberlado Barbosa", "articlepkg_id": 1, "comments": [], "is_open": true, "started_at": "2013-10-09 16:44:29.865787", "id": 2, "resource_uri": "/api/v1/tickets/2/"}]}'))
+        ticket1_id = self._loaded_fixtures[1].id
+        articlepkg1_id = self._loaded_fixtures[1].articlepkg.id
+
+        res = self.testapp.get('/api/v1/tickets/?limit=2')
+        expected = '''{"meta": {"previous": null, "next": "/api/v1/tickets/?limit=2&offset=2", "total": 3, "limit": 2, "offset": 0},
+                       "objects": [
+                           {"title": "Erro no pacote xxx",
+                            "finished_at": null,
+                            "author": "Aberlado Barbosa",
+                            "articlepkg_id": %s,
+                            "comments": [],
+                            "is_open": true,
+                            "started_at": "2013-10-09 16:44:29.865787",
+                            "id": %s,
+                            "resource_uri": "/api/v1/tickets/%s/"},
+                           {"title": "Erro no pacote xxx",
+                            "finished_at": null,
+                            "author": "Aberlado Barbosa",
+                            "articlepkg_id": %s,
+                            "comments": [],
+                            "is_open": true,
+                            "started_at": "2013-10-09 16:44:29.865787",
+                            "id": %s,
+                            "resource_uri": "/api/v1/tickets/%s/"}
+                    ]}''' % (articlepkg0_id, ticket0_id, ticket0_id,
+                             articlepkg1_id, ticket1_id, ticket1_id)
+
+        self.assertEqual(json.loads(res.body), json.loads(expected))
 
     def test_GET_to_tickets_with_param_low_offset_and_limit(self):
+        ticket1_id = self._loaded_fixtures[1].id
+        articlepkg1_id = self._loaded_fixtures[1].articlepkg.id
+
+        ticket2_id = self._loaded_fixtures[2].id
+        articlepkg2_id = self._loaded_fixtures[2].articlepkg.id
+
         res = self.testapp.get('/api/v1/tickets/?limit=2&offset=1')
 
-        self.assertEqual(json.loads(res.body), json.loads('{"meta": {"previous": null, "next": "/api/v1/tickets/?limit=2&offset=3", "total": 3, "limit": 2, "offset": "1"}, "objects": [{"title": "Erro no pacote xxx", "finished_at": null, "author": "Aberlado Barbosa", "articlepkg_id": 1, "comments": [], "is_open": true, "started_at": "2013-10-09 16:44:29.865787", "id": 2, "resource_uri": "/api/v1/tickets/2/"}, {"title": "Erro no pacote xxx", "finished_at": null, "author": "Aberlado Barbosa", "articlepkg_id": 1, "comments": [], "is_open": true, "started_at": "2013-10-09 16:44:29.865787", "id": 3, "resource_uri": "/api/v1/tickets/3/"}]}'))
+        expected = '''{"meta": {"previous": null, "next": "/api/v1/tickets/?limit=2&offset=3", "total": 3, "limit": 2, "offset": "1"},
+                       "objects": [
+                           {"title": "Erro no pacote xxx",
+                            "finished_at": null,
+                            "author": "Aberlado Barbosa",
+                            "articlepkg_id": %s,
+                            "comments": [],
+                            "is_open": true,
+                            "started_at": "2013-10-09 16:44:29.865787",
+                            "id": %s,
+                            "resource_uri": "/api/v1/tickets/%s/"},
+                           {"title": "Erro no pacote xxx",
+                            "finished_at": null,
+                            "author": "Aberlado Barbosa",
+                            "articlepkg_id": %s,
+                            "comments": [],
+                            "is_open": true,
+                            "started_at": "2013-10-09 16:44:29.865787",
+                            "id": %s,
+                            "resource_uri": "/api/v1/tickets/%s/"}
+                    ]}''' % (articlepkg1_id, ticket1_id, ticket1_id,
+                             articlepkg2_id, ticket2_id, ticket2_id)
+
+        self.assertEqual(json.loads(res.body), json.loads(expected))
 
     def test_GET_to_tickets_with_param_low_limit_and_offset(self):
+        ticket2_id = self._loaded_fixtures[2].id
+        articlepkg2_id = self._loaded_fixtures[2].articlepkg.id
+
         res = self.testapp.get('/api/v1/tickets/?limit=1&offset=2')
 
-        self.assertEqual(json.loads(res.body), json.loads('{"meta": {"previous": "/api/v1/tickets/?limit=1&offset=1", "next": "/api/v1/tickets/?limit=1&offset=3", "total": 3, "limit": 1, "offset": "2"}, "objects": [{"title": "Erro no pacote xxx", "finished_at": null, "author": "Aberlado Barbosa", "articlepkg_id": 1, "comments": [], "is_open": true, "started_at": "2013-10-09 16:44:29.865787", "id": 3, "resource_uri": "/api/v1/tickets/3/"}]}'))
+        expected = '''{"meta": {"previous": "/api/v1/tickets/?limit=1&offset=1", "next": "/api/v1/tickets/?limit=1&offset=3", "total": 3, "limit": 1, "offset": "2"},
+                       "objects": [
+                           {"title": "Erro no pacote xxx",
+                            "finished_at": null,
+                            "author": "Aberlado Barbosa",
+                            "articlepkg_id": %s,
+                            "comments": [],
+                            "is_open": true,
+                            "started_at": "2013-10-09 16:44:29.865787",
+                            "id": %s,
+                            "resource_uri": "/api/v1/tickets/%s/"}
+                    ]}''' % (articlepkg2_id, ticket2_id, ticket2_id)
+
+        self.assertEqual(json.loads(res.body), json.loads(expected))
 
     def test_POST_to_create_ticket_without_message(self):
+        articlepkg_id = self._loaded_fixtures[0].articlepkg.id
+        models.ScopedSession.flush()  # avoid integrity errors
+
         res = self.testapp.post('/api/v1/tickets/',
                 {
-                 'articlepkg_id': 1,
+                 'articlepkg_id': articlepkg_id,
                  'title': 'Article about xxx',
                  'ticket_author': 'Aberlado Barbosa',
                 })
@@ -459,9 +608,12 @@ class TicketFunctionalAPITest(unittest.TestCase):
         self.assertEqual(res.status_code, 201)
 
     def test_POST_to_create_ticket_with_message(self):
+        articlepkg_id = self._loaded_fixtures[0].articlepkg.id
+        models.ScopedSession.flush()  # avoid integrity errors
+
         res = self.testapp.post('/api/v1/tickets/',
                 {
-                 'articlepkg_id': 1,
+                 'articlepkg_id': articlepkg_id,
                  'title': 'Article about xxx',
                  'ticket_author': 'Aberlado Barbosa',
                  'message': 'Error on validation....'

--- a/balaio/tests/test_gateway_server.py
+++ b/balaio/tests/test_gateway_server.py
@@ -10,21 +10,22 @@ from sqlalchemy import create_engine
 from webtest import TestApp
 import transaction
 
-from balaio import models
-from balaio import gateway_server
-from balaio.tests.doubles import *
-from balaio.gateway_server import main
+from balaio import models, gateway_server
+from .doubles import *
+from .utils import db_bootstrap
+from . import modelfactories
 
 
 sys.path.append(os.path.dirname(__file__) + '/../')
+global_engine = None
 
 
-def _init_test_DB():
-
-    engine = create_engine('sqlite://')
-    models.Base.metadata.create_all(engine)
-
-    models.ScopedSession.configure(bind=engine)
+def setUpModule():
+    """
+    Initialize the database.
+    """
+    global global_engine
+    global_engine = db_bootstrap()
 
 
 def _load_fixtures(obj_list):
@@ -36,15 +37,12 @@ def _load_fixtures(obj_list):
 class FunctionalAPITest(unittest.TestCase):
 
     def setUp(self):
-        self.session = models.ScopedSession
         self.config = testing.setUp()
-        engine = create_engine('sqlite://')
-
-        app = main(ConfigStub(), engine)
+        app = gateway_server.main(ConfigStub(), global_engine)
         self.testapp = TestApp(app)
 
     def tearDown(self):
-        self.session.remove()
+        models.ScopedSession.remove()
         testing.tearDown()
 
     def test_root(self):
@@ -58,98 +56,293 @@ class FunctionalAPITest(unittest.TestCase):
 class AttemptFunctionalAPITest(unittest.TestCase):
 
     def setUp(self):
-        _init_test_DB()
-        _load_fixtures(self._makeList())
-
-        self.session = models.ScopedSession
+        self._loaded_fixtures = [self._makeOne() for i in range(3)]
         self.config = testing.setUp()
-        engine = create_engine('sqlite://')
 
-        app = main(ConfigStub(), engine)
+        app = gateway_server.main(ConfigStub(), global_engine)
         self.testapp = TestApp(app)
 
     def tearDown(self):
-        self.session.remove()
+        transaction.abort()
+        models.ScopedSession.remove()
         testing.tearDown()
 
-    def _makeOne(self, id=1):
+    def _makeOne(self):
         import datetime
-
-        attempt = models.Attempt(id=id,
-                    package_checksum='20132df0as89dds73as936' + str(id),
-                    started_at=datetime.datetime(2013, 10, 9, 16, 44, 29, 865787),
-                    finished_at=None,
-                    collection_uri='http://www.scielo.br',
-                    articlepkg_id=1,
-                    filepath='/tmp/watch/xxx.zip',
-                    is_valid=True)
-
+        attempt = modelfactories.AttemptFactory.create()
         attempt.started_at = datetime.datetime(2013, 10, 9, 16, 44, 29, 865787)
-
         return attempt
-
-    def _makeList(self):
-        return [self._makeOne(), self._makeOne(2), self._makeOne(3)]
 
     def test_GET_to_available_resource(self):
         self.testapp.get('/api/v1/attempts/', status=200)
 
     def test_GET_to_one_attempt(self):
-        res = self.testapp.get('/api/v1/attempts/1/')
+        attempt_id = self._loaded_fixtures[0].id
+        attempt_checksum = self._loaded_fixtures[0].package_checksum
+        articlepkg_id = self._loaded_fixtures[0].articlepkg.id
 
-        self.assertEqual(json.loads(res.body), json.loads('{"collection_uri": "http://www.scielo.br", "filepath": "/tmp/watch/xxx.zip", "finished_at": null, "articlepkg_id": 1, "is_valid": true, "started_at": "2013-10-09 16:44:29.865787", "id": 1, "package_checksum": "20132df0as89dds73as9361", "resource_uri": "/api/v1/attempts/1/"}'))
+        res = self.testapp.get('/api/v1/attempts/%s/' % attempt_id)
+
+        expected = '''{"collection_uri": "",
+                       "filepath": "/tmp/watch/xxx.zip",
+                       "finished_at": null,
+                       "articlepkg_id": %s,
+                       "is_valid": true,
+                       "started_at": "2013-10-09 16:44:29.865787",
+                       "id": %s,
+                       "package_checksum": "%s",
+                       "resource_uri": "/api/v1/attempts/%s/"}''' % (articlepkg_id, attempt_id, attempt_checksum, attempt_id)
+
+        self.assertEqual(json.loads(res.body), json.loads(expected))
 
     def test_GET_to_attempts(self):
+        attempt0_id = self._loaded_fixtures[0].id
+        attempt0_checksum = self._loaded_fixtures[0].package_checksum
+        articlepkg0_id = self._loaded_fixtures[0].articlepkg.id
+
+        attempt1_id = self._loaded_fixtures[1].id
+        attempt1_checksum = self._loaded_fixtures[1].package_checksum
+        articlepkg1_id = self._loaded_fixtures[1].articlepkg.id
+
+        attempt2_id = self._loaded_fixtures[2].id
+        attempt2_checksum = self._loaded_fixtures[2].package_checksum
+        articlepkg2_id = self._loaded_fixtures[2].articlepkg.id
+
         res = self.testapp.get('/api/v1/attempts/')
 
-        self.assertEqual(json.loads(res.body), json.loads('{"meta": {"previous": null, "next": null, "total": 3, "limit": 20, "offset": 0}, "objects": [{"collection_uri": "http://www.scielo.br", "filepath": "/tmp/watch/xxx.zip", "finished_at": null, "articlepkg_id": 1, "is_valid": true, "started_at": "2013-10-09 16:44:29.865787", "id": 1, "package_checksum": "20132df0as89dds73as9361", "resource_uri": "/api/v1/attempts/1/"}, {"collection_uri": "http://www.scielo.br", "filepath": "/tmp/watch/xxx.zip", "finished_at": null, "articlepkg_id": 1, "is_valid": true, "started_at": "2013-10-09 16:44:29.865787", "id": 2, "package_checksum": "20132df0as89dds73as9362", "resource_uri": "/api/v1/attempts/2/"}, {"collection_uri": "http://www.scielo.br", "filepath": "/tmp/watch/xxx.zip", "finished_at": null, "articlepkg_id": 1, "is_valid": true, "started_at": "2013-10-09 16:44:29.865787", "id": 3, "package_checksum": "20132df0as89dds73as9363", "resource_uri": "/api/v1/attempts/3/"}]}'))
+        expected = '''{"meta": {"previous": null, "next": null, "total": 3, "limit": 20, "offset": 0},
+                       "objects": [
+                           {"collection_uri": "",
+                            "filepath": "/tmp/watch/xxx.zip",
+                            "finished_at": null,
+                            "articlepkg_id": %s,
+                            "is_valid": true,
+                            "started_at": "2013-10-09 16:44:29.865787",
+                            "id": %s,
+                            "package_checksum": "%s",
+                            "resource_uri": "/api/v1/attempts/%s/"},
+                           {"collection_uri": "",
+                            "filepath": "/tmp/watch/xxx.zip",
+                            "finished_at": null,
+                            "articlepkg_id": %s,
+                            "is_valid": true,
+                            "started_at": "2013-10-09 16:44:29.865787",
+                            "id": %s,
+                            "package_checksum": "%s",
+                            "resource_uri": "/api/v1/attempts/%s/"},
+                           {"collection_uri": "",
+                            "filepath": "/tmp/watch/xxx.zip",
+                            "finished_at": null,
+                            "articlepkg_id": %s,
+                            "is_valid": true,
+                            "started_at": "2013-10-09 16:44:29.865787",
+                            "id": %s,
+                            "package_checksum": "%s",
+                            "resource_uri": "/api/v1/attempts/%s/"}
+                        ]
+                    }''' % (articlepkg0_id, attempt0_id, attempt0_checksum, attempt0_id,
+                            articlepkg1_id, attempt1_id, attempt1_checksum, attempt1_id,
+                            articlepkg2_id, attempt2_id, attempt2_checksum, attempt2_id)
+
+        self.assertEqual(json.loads(res.body), json.loads(expected))
 
     def test_GET_to_attempts_with_param_limit(self):
+        attempt0_id = self._loaded_fixtures[0].id
+        attempt0_checksum = self._loaded_fixtures[0].package_checksum
+        articlepkg0_id = self._loaded_fixtures[0].articlepkg.id
+
+        attempt1_id = self._loaded_fixtures[1].id
+        attempt1_checksum = self._loaded_fixtures[1].package_checksum
+        articlepkg1_id = self._loaded_fixtures[1].articlepkg.id
+
+        attempt2_id = self._loaded_fixtures[2].id
+        attempt2_checksum = self._loaded_fixtures[2].package_checksum
+        articlepkg2_id = self._loaded_fixtures[2].articlepkg.id
+
         res = self.testapp.get('/api/v1/attempts/?limit=45')
 
-        self.assertEqual(json.loads(res.body), json.loads('{"meta": {"previous": null, "next": null, "total": 3, "limit": 45, "offset": 0}, "objects": [{"collection_uri": "http://www.scielo.br", "filepath": "/tmp/watch/xxx.zip", "finished_at": null, "articlepkg_id": 1, "is_valid": true, "started_at": "2013-10-09 16:44:29.865787", "id": 1, "package_checksum": "20132df0as89dds73as9361", "resource_uri": "/api/v1/attempts/1/"}, {"collection_uri": "http://www.scielo.br", "filepath": "/tmp/watch/xxx.zip", "finished_at": null, "articlepkg_id": 1, "is_valid": true, "started_at": "2013-10-09 16:44:29.865787", "id": 2, "package_checksum": "20132df0as89dds73as9362", "resource_uri": "/api/v1/attempts/2/"}, {"collection_uri": "http://www.scielo.br", "filepath": "/tmp/watch/xxx.zip", "finished_at": null, "articlepkg_id": 1, "is_valid": true, "started_at": "2013-10-09 16:44:29.865787", "id": 3, "package_checksum": "20132df0as89dds73as9363", "resource_uri": "/api/v1/attempts/3/"}]}'))
+        expected = '''{"meta": {"previous": null, "next": null, "total": 3, "limit": 45, "offset": 0},
+                       "objects": [
+                           {"collection_uri": "",
+                            "filepath": "/tmp/watch/xxx.zip",
+                            "finished_at": null,
+                            "articlepkg_id": %s,
+                            "is_valid": true,
+                            "started_at": "2013-10-09 16:44:29.865787",
+                            "id": %s,
+                            "package_checksum": "%s",
+                            "resource_uri": "/api/v1/attempts/%s/"},
+                           {"collection_uri": "",
+                            "filepath": "/tmp/watch/xxx.zip",
+                            "finished_at": null,
+                            "articlepkg_id": %s,
+                            "is_valid": true,
+                            "started_at": "2013-10-09 16:44:29.865787",
+                            "id": %s,
+                            "package_checksum": "%s",
+                            "resource_uri": "/api/v1/attempts/%s/"},
+                           {"collection_uri": "",
+                            "filepath": "/tmp/watch/xxx.zip",
+                            "finished_at": null,
+                            "articlepkg_id": %s,
+                            "is_valid": true,
+                            "started_at": "2013-10-09 16:44:29.865787",
+                            "id": %s,
+                            "package_checksum": "%s",
+                            "resource_uri": "/api/v1/attempts/%s/"}
+                    ]}'''% (articlepkg0_id, attempt0_id, attempt0_checksum, attempt0_id,
+                            articlepkg1_id, attempt1_id, attempt1_checksum, attempt1_id,
+                            articlepkg2_id, attempt2_id, attempt2_checksum, attempt2_id)
+
+        self.assertEqual(json.loads(res.body), json.loads(expected))
 
     def test_GET_to_attempts_with_param_offset(self):
+        attempt1_id = self._loaded_fixtures[1].id
+        attempt1_checksum = self._loaded_fixtures[1].package_checksum
+        articlepkg1_id = self._loaded_fixtures[1].articlepkg.id
+
+        attempt2_id = self._loaded_fixtures[2].id
+        attempt2_checksum = self._loaded_fixtures[2].package_checksum
+        articlepkg2_id = self._loaded_fixtures[2].articlepkg.id
+
         res = self.testapp.get('/api/v1/attempts/?offset=1')
 
-        self.assertEqual(json.loads(res.body), json.loads('{"meta": {"previous": null, "next": null, "total": 3, "limit": 20, "offset": "1"}, "objects": [{"collection_uri": "http://www.scielo.br", "filepath": "/tmp/watch/xxx.zip", "finished_at": null, "articlepkg_id": 1, "is_valid": true, "started_at": "2013-10-09 16:44:29.865787", "id": 2, "package_checksum": "20132df0as89dds73as9362", "resource_uri": "/api/v1/attempts/2/"}, {"collection_uri": "http://www.scielo.br", "filepath": "/tmp/watch/xxx.zip", "finished_at": null, "articlepkg_id": 1, "is_valid": true, "started_at": "2013-10-09 16:44:29.865787", "id": 3, "package_checksum": "20132df0as89dds73as9363", "resource_uri": "/api/v1/attempts/3/"}]}'))
+        expected = '''{"meta": {"previous": null, "next": null, "total": 3, "limit": 20, "offset": "1"},
+                       "objects": [
+                         {"collection_uri": "",
+                          "filepath": "/tmp/watch/xxx.zip",
+                          "finished_at": null,
+                          "articlepkg_id": %s,
+                          "is_valid": true,
+                          "started_at": "2013-10-09 16:44:29.865787",
+                          "id": %s,
+                          "package_checksum": "%s",
+                          "resource_uri": "/api/v1/attempts/%s/"},
+                         {"collection_uri": "",
+                          "filepath": "/tmp/watch/xxx.zip",
+                          "finished_at": null,
+                          "articlepkg_id": %s,
+                          "is_valid": true,
+                          "started_at": "2013-10-09 16:44:29.865787",
+                          "id": %s,
+                          "package_checksum": "%s",
+                          "resource_uri": "/api/v1/attempts/%s/"}
+                        ]}''' % (articlepkg1_id, attempt1_id, attempt1_checksum, attempt1_id,
+                                 articlepkg2_id, attempt2_id, attempt2_checksum, attempt2_id)
+
+        self.assertEqual(json.loads(res.body), json.loads(expected))
 
     def test_GET_to_attempts_with_param_offset_and_limit(self):
         res = self.testapp.get('/api/v1/attempts/?offset=4&limit=78')
+        expected = '{"meta": {"previous": null, "next": null, "total": 3, "limit": 78, "offset": "4"}, "objects": []}'
 
-        self.assertEqual(json.loads(res.body), json.loads('{"meta": {"previous": null, "next": null, "total": 3, "limit": 78, "offset": "4"}, "objects": []}'))
+        self.assertEqual(json.loads(res.body), json.loads(expected))
 
     def test_GET_to_attempts_with_param_low_limit(self):
+        attempt0_id = self._loaded_fixtures[0].id
+        attempt0_checksum = self._loaded_fixtures[0].package_checksum
+        articlepkg0_id = self._loaded_fixtures[0].articlepkg.id
+
+        attempt1_id = self._loaded_fixtures[1].id
+        attempt1_checksum = self._loaded_fixtures[1].package_checksum
+        articlepkg1_id = self._loaded_fixtures[1].articlepkg.id
+
         res = self.testapp.get('/api/v1/attempts/?limit=2')
 
-        self.assertEqual(json.loads(res.body), json.loads('{"meta": {"previous": null, "next": "/api/v1/attempts/?limit=2&offset=2", "total": 3, "limit": 2, "offset": 0}, "objects": [{"collection_uri": "http://www.scielo.br", "filepath": "/tmp/watch/xxx.zip", "finished_at": null, "articlepkg_id": 1, "is_valid": true, "started_at": "2013-10-09 16:44:29.865787", "id": 1, "package_checksum": "20132df0as89dds73as9361", "resource_uri": "/api/v1/attempts/1/"}, {"collection_uri": "http://www.scielo.br", "filepath": "/tmp/watch/xxx.zip", "finished_at": null, "articlepkg_id": 1, "is_valid": true, "started_at": "2013-10-09 16:44:29.865787", "id": 2, "package_checksum": "20132df0as89dds73as9362", "resource_uri": "/api/v1/attempts/2/"}]}'))
+        expected = '''{"meta": {"previous": null, "next": "/api/v1/attempts/?limit=2&offset=2", "total": 3, "limit": 2, "offset": 0},
+                       "objects": [
+                         {"collection_uri": "",
+                          "filepath": "/tmp/watch/xxx.zip",
+                          "finished_at": null,
+                          "articlepkg_id": %s,
+                          "is_valid": true,
+                          "started_at": "2013-10-09 16:44:29.865787",
+                          "id": %s,
+                          "package_checksum": "%s",
+                          "resource_uri": "/api/v1/attempts/%s/"},
+                         {"collection_uri": "",
+                          "filepath": "/tmp/watch/xxx.zip",
+                          "finished_at": null,
+                          "articlepkg_id": %s,
+                          "is_valid": true,
+                          "started_at": "2013-10-09 16:44:29.865787",
+                          "id": %s,
+                          "package_checksum": "%s",
+                          "resource_uri": "/api/v1/attempts/%s/"}
+                        ]}''' % (articlepkg0_id, attempt0_id, attempt0_checksum, attempt0_id,
+                                 articlepkg1_id, attempt1_id, attempt1_checksum, attempt1_id)
+
+        self.assertEqual(json.loads(res.body), json.loads(expected))
 
     def test_GET_to_attempts_with_param_low_offset_and_limit(self):
+        attempt1_id = self._loaded_fixtures[1].id
+        attempt1_checksum = self._loaded_fixtures[1].package_checksum
+        articlepkg1_id = self._loaded_fixtures[1].articlepkg.id
+
+        attempt2_id = self._loaded_fixtures[2].id
+        attempt2_checksum = self._loaded_fixtures[2].package_checksum
+        articlepkg2_id = self._loaded_fixtures[2].articlepkg.id
+
         res = self.testapp.get('/api/v1/attempts/?limit=2&offset=1')
 
-        self.assertEqual(json.loads(res.body), json.loads('{"meta": {"previous": null, "next": "/api/v1/attempts/?limit=2&offset=3", "total": 3, "limit": 2, "offset": "1"}, "objects": [{"collection_uri": "http://www.scielo.br", "filepath": "/tmp/watch/xxx.zip", "finished_at": null, "articlepkg_id": 1, "is_valid": true, "started_at": "2013-10-09 16:44:29.865787", "id": 2, "package_checksum": "20132df0as89dds73as9362", "resource_uri": "/api/v1/attempts/2/"}, {"collection_uri": "http://www.scielo.br", "filepath": "/tmp/watch/xxx.zip", "finished_at": null, "articlepkg_id": 1, "is_valid": true, "started_at": "2013-10-09 16:44:29.865787", "id": 3, "package_checksum": "20132df0as89dds73as9363", "resource_uri": "/api/v1/attempts/3/"}]}'))
+        expected = '''{"meta": {"previous": null, "next": "/api/v1/attempts/?limit=2&offset=3", "total": 3, "limit": 2, "offset": "1"},
+                       "objects": [
+                           {"collection_uri": "",
+                            "filepath": "/tmp/watch/xxx.zip",
+                            "finished_at": null,
+                            "articlepkg_id": %s,
+                            "is_valid": true,
+                            "started_at": "2013-10-09 16:44:29.865787",
+                            "id": %s,
+                            "package_checksum": "%s",
+                            "resource_uri": "/api/v1/attempts/%s/"},
+                           {"collection_uri": "",
+                            "filepath": "/tmp/watch/xxx.zip",
+                            "finished_at": null,
+                            "articlepkg_id": %s,
+                            "is_valid": true,
+                            "started_at": "2013-10-09 16:44:29.865787",
+                            "id": %s,
+                            "package_checksum": "%s",
+                            "resource_uri": "/api/v1/attempts/%s/"}
+                         ]}'''% (articlepkg1_id, attempt1_id, attempt1_checksum, attempt1_id,
+                                 articlepkg2_id, attempt2_id, attempt2_checksum, attempt2_id)
+
+        self.assertEqual(json.loads(res.body), json.loads(expected))
 
     def test_GET_to_attempts_with_param_low_limit_and_offset(self):
+        attempt2_id = self._loaded_fixtures[2].id
+        attempt2_checksum = self._loaded_fixtures[2].package_checksum
+        articlepkg2_id = self._loaded_fixtures[2].articlepkg.id
+
         res = self.testapp.get('/api/v1/attempts/?limit=1&offset=2')
 
-        self.assertEqual(json.loads(res.body), json.loads('{"meta": {"previous": "/api/v1/attempts/?limit=1&offset=1", "next": "/api/v1/attempts/?limit=1&offset=3", "total": 3, "limit": 1, "offset": "2"}, "objects": [{"collection_uri": "http://www.scielo.br", "filepath": "/tmp/watch/xxx.zip", "finished_at": null, "articlepkg_id": 1, "is_valid": true, "started_at": "2013-10-09 16:44:29.865787", "id": 3, "package_checksum": "20132df0as89dds73as9363", "resource_uri": "/api/v1/attempts/3/"}]}'))
+        expected = '''{"meta": {"previous": "/api/v1/attempts/?limit=1&offset=1", "next": "/api/v1/attempts/?limit=1&offset=3", "total": 3, "limit": 1, "offset": "2"},
+                       "objects": [
+                           {"collection_uri": "",
+                            "filepath": "/tmp/watch/xxx.zip",
+                            "finished_at": null,
+                            "articlepkg_id": %s,
+                            "is_valid": true,
+                            "started_at": "2013-10-09 16:44:29.865787",
+                            "id": %s,
+                            "package_checksum": "%s",
+                            "resource_uri": "/api/v1/attempts/%s/"}
+                         ]}''' % (articlepkg2_id, attempt2_id, attempt2_checksum, attempt2_id)
+
+        self.assertEqual(json.loads(res.body), json.loads(expected))
 
 
 class TicketFunctionalAPITest(unittest.TestCase):
 
     def setUp(self):
-        _init_test_DB()
         _load_fixtures(self._makeList())
-
-        self.session = models.ScopedSession
         self.config = testing.setUp()
-        engine = create_engine('sqlite://')
-
-        app = main(ConfigStub(), engine)
+        app = gateway_server.main(ConfigStub(), global_engine)
         self.testapp = TestApp(app)
 
     def tearDown(self):
-        self.session.remove()
+        models.ScopedSession.remove()
         testing.tearDown()
 
     def _makeOne(self, id=1):
@@ -262,18 +455,13 @@ class TicketFunctionalAPITest(unittest.TestCase):
 class PackageFunctionalAPITest(unittest.TestCase):
 
     def setUp(self):
-        _init_test_DB()
         _load_fixtures(self._makeList())
-
-        self.session = models.ScopedSession
         self.config = testing.setUp()
-        engine = create_engine('sqlite://')
-
-        app = main(ConfigStub(), engine)
+        app = gateway_server.main(ConfigStub(), global_engine)
         self.testapp = TestApp(app)
 
     def tearDown(self):
-        self.session.remove()
+        models.ScopedSession.remove()
         testing.tearDown()
 
     def _makeOne(self, id=1):

--- a/balaio/tests/test_models.py
+++ b/balaio/tests/test_models.py
@@ -175,11 +175,11 @@ class ArticlePkgTests(mocker.MockerTestCase):
 
         pkg_analyzer = doubles.PackageAnalyzerStub()
         pkg_analyzer.criteria = {'article_title': 'foo', 'journal_eissn':'1234-1234', 'journal_pissn':'1234-4321'}
-    
+
         mock_session.query(ArticlePkg)
         self.mocker.result(mock_session)
 
-        mock_session.filter_by(**pkg_analyzer.criteria)
+        mock_session.filter_by(article_title='foo')
         self.mocker.result(mock_session)
 
         mock_session.one()

--- a/balaio/tests/test_vpipes.py
+++ b/balaio/tests/test_vpipes.py
@@ -11,7 +11,7 @@ class ValidationPipeTests(mocker.MockerTestCase):
     def _makeOne(self, data, **kwargs):
         from balaio import vpipes
         _notifier = kwargs.get('_notifier', lambda args: NotifierStub)
-        
+
         vpipe = vpipes.ValidationPipe(notifier=_notifier)
         vpipe.feed(data)
         return vpipe
@@ -32,7 +32,7 @@ class ValidationPipeTests(mocker.MockerTestCase):
         vpipes.ValidationPipe._notifier = NotifierStub()
         mock_self = self.mocker.mock(vpipes.ValidationPipe)
 
-        item = [AttemptStub(), ArticlePkgStub(), {}]
+        item = [AttemptStub(), ArticlePkgStub(), {}, SessionStub()]
 
         mock_self.validate(item)
         self.mocker.result([models.Status.ok, 'foo'])
@@ -40,9 +40,7 @@ class ValidationPipeTests(mocker.MockerTestCase):
         mock_self._stage_
         self.mocker.result('bar')
 
-        #mock_self._notifier.validation_event(mocker.ANY)
-        # self.mocker.result(None)
-        mock_self._notifier(item[0])
+        mock_self._notifier(item[0], item[3])
         self.mocker.result(NotifierStub())
 
         self.mocker.replay()

--- a/balaio/tests/utils.py
+++ b/balaio/tests/utils.py
@@ -1,6 +1,10 @@
 from sqlalchemy import create_engine
+from sqlalchemy.exc import OperationalError
 
 from balaio import models
+
+
+DB_NAME = 'app_balaio_tests'
 
 
 def db_bootstrap():
@@ -14,8 +18,11 @@ def db_bootstrap():
 
     :returns: an instance of engine.
     """
-    engine = create_engine('postgresql+psycopg2://postgres:@localhost/app_balaio_tests', echo=False)
-    models.Base.metadata.drop_all(engine)
+    engine = create_engine('postgresql+psycopg2://postgres:@localhost/%s' % DB_NAME, echo=False)
+    try:
+        models.Base.metadata.drop_all(engine)
+    except OperationalError as e:
+        exit('You DB is not properly configured. Make sure the db `%s` exists. Traceback: %s' % (DB_NAME, e))
     models.init_database(engine)
 
     # patch the module function

--- a/balaio/tests/utils.py
+++ b/balaio/tests/utils.py
@@ -14,7 +14,7 @@ def db_bootstrap():
 
     :returns: an instance of engine.
     """
-    engine = create_engine('postgresql+psycopg2://postgres:@localhost/app_balaio', echo=False)
+    engine = create_engine('postgresql+psycopg2://postgres:@localhost/app_balaio_tests', echo=False)
     models.Base.metadata.drop_all(engine)
     models.init_database(engine)
 

--- a/balaio/tests/utils.py
+++ b/balaio/tests/utils.py
@@ -7,7 +7,7 @@ def db_bootstrap():
     """
     Prepares the database to run tests.
 
-    It binds a sqlalchemy engine, creates all db schema,
+    It binds a sqlalchemy engine, recreates all db schema,
     patches `models.create_engine_from_config`, configures
     `models.Session` and `models.ScopedSession` globally
     and returns the engine.

--- a/balaio/tests/utils.py
+++ b/balaio/tests/utils.py
@@ -1,0 +1,26 @@
+from sqlalchemy import create_engine
+
+from balaio import models
+
+
+def db_bootstrap():
+    """
+    Prepares the database to run tests.
+
+    It binds a sqlalchemy engine, creates all db schema,
+    patches `models.create_engine_from_config`, configures
+    `models.Session` and `models.ScopedSession` globally
+    and returns the engine.
+
+    :returns: an instance of engine.
+    """
+    engine = create_engine('postgresql+psycopg2://postgres:@localhost/app_balaio', echo=False)
+    models.init_database(engine)
+
+    # patch the module function
+    models.create_engine_from_config = lambda config: engine
+    models.Session.configure(bind=engine)
+    models.ScopedSession.configure(bind=engine)
+
+    return engine
+

--- a/balaio/tests/utils.py
+++ b/balaio/tests/utils.py
@@ -15,6 +15,7 @@ def db_bootstrap():
     :returns: an instance of engine.
     """
     engine = create_engine('postgresql+psycopg2://postgres:@localhost/app_balaio', echo=False)
+    models.Base.metadata.drop_all(engine)
     models.init_database(engine)
 
     # patch the module function

--- a/balaio/vpipes.py
+++ b/balaio/vpipes.py
@@ -1,6 +1,7 @@
 import logging
 
 from plumber import Pipe, Pipeline, precondition, UnmetPrecondition
+import transaction
 
 import scieloapitoolbelt
 
@@ -35,11 +36,18 @@ class ValidationPipe(Pipe):
         `item` is a tuple comprised of instances of models.Attempt, a
         checkin.PackageAnalyzer, a dict of journal and issue data.
         """
-        logger.debug('%s started processing %s' % (self.__class__.__name__, item[0]))
+        attempt = item[0]
+        db_session = item[3]
+        logger.debug('%s started processing %s' % (self.__class__.__name__, attempt))
 
         result_status, result_description = self.validate(item)
 
-        self._notifier(item[0]).tell(result_description, result_status, label=self._stage_)
+        savepoint = transaction.savepoint()
+        try:
+            self._notifier(attempt, db_session).tell(result_description, result_status, label=self._stage_)
+        except Exception as e:
+            savepoint.rollback()
+            raise
 
         return item
 

--- a/balaio/vpipes.py
+++ b/balaio/vpipes.py
@@ -11,7 +11,7 @@ logger = logging.getLogger(__name__)
 
 def attempt_is_valid(data):
     try:
-        attempt, _, __ = data
+        attempt, _, _, _ = data
     except TypeError:
         attempt = data
 
@@ -47,6 +47,7 @@ class ValidationPipe(Pipe):
             self._notifier(attempt, db_session).tell(result_description, result_status, label=self._stage_)
         except Exception as e:
             savepoint.rollback()
+            logger.error('An exception was raised during %s stage: %s' % (self._stage_, e))
             raise
 
         return item

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,4 @@ transaction
 zope.sqlalchemy
 psycopg2
 lxml
+factory_boy


### PR DESCRIPTION
Bonus:
- `checkin.get_attempt` agora trabalha com savepoints para associação com `ArticlePkg`;
- As notificações dos pipes de validação são executadas dentro de um contexto transacional;

*_Para executar os testes, é necessário criar um DB chamado *app_balaio_tests_ **
