### PR TITLE
Envio de notificações de checkin

### DIFF
--- a/balaio/models.py
+++ b/balaio/models.py
@@ -62,6 +62,7 @@ class Attempt(Base):
     collection_uri = Column(String)
     filepath = Column(String)
     is_valid = Column(Boolean)
+    checkin_uri = Column(String(length=64), nullable=True)
 
     articlepkg = relationship('ArticlePkg',
                               backref=backref('attempts',

--- a/balaio/models.py
+++ b/balaio/models.py
@@ -291,7 +291,7 @@ class Checkpoint(Base):
     attempt = relationship('Attempt',
                            backref=backref('checkpoint'))
 
-    def __init__(self, point):
+    def __init__(self, point, **kwargs):
         """
         Represents a time delta of a checkpoint execution.
 
@@ -301,6 +301,8 @@ class Checkpoint(Base):
 
         :param point: a known checkpoint, represented as :class:`Point`.
         """
+        super(Checkpoint, self).__init__(**kwargs)
+
         if point not in Point:
             raise ValueError('point must be %s' % ','.join(str(pt) for pt in Point))
 

--- a/balaio/monitor.py
+++ b/balaio/monitor.py
@@ -142,8 +142,8 @@ if __name__ == '__main__':
 
     wm.add_watch(config.get('monitor', 'watch_path').split(','),
                  mask,
-                 rec=config.get('monitor', 'recursive'),
-                 auto_add=config.get('monitor', 'recursive'))
+                 rec=config.getboolean('monitor', 'recursive'),
+                 auto_add=config.getboolean('monitor', 'recursive'))
 
     logger.info('Watching %s' % config.get('monitor', 'watch_path'))
 

--- a/balaio/tests/doubles.py
+++ b/balaio/tests/doubles.py
@@ -294,4 +294,12 @@ class DummyRoutesMapper:
 
 
 class SessionStub(object):
-    pass
+    def __init__(self):
+        self._items = []
+
+    def __contains__(self, item):
+        return item in self._items
+
+    def add(self, item):
+        self._items.append(item)
+

--- a/balaio/tests/modelfactories.py
+++ b/balaio/tests/modelfactories.py
@@ -41,3 +41,12 @@ class TicketFactory(SQLAlchemyModelFactory):
     author = 'Aberlado Barbosa'
     articlepkg = factory.SubFactory(ArticlePkgFactory)
 
+
+class CheckpointFactory(SQLAlchemyModelFactory):
+    FACTORY_FOR = models.Checkpoint
+    FACTORY_SESSION = models.ScopedSession
+
+    id = factory.Sequence(lambda n: n)
+    point = models.Point.checkin
+    attempt = factory.SubFactory(AttemptFactory)
+

--- a/balaio/tests/test_notifier.py
+++ b/balaio/tests/test_notifier.py
@@ -1,0 +1,74 @@
+import unittest
+
+import mocker
+
+from balaio.notifier import Notifier
+from balaio import models
+from . import doubles, modelfactories
+from .utils import db_bootstrap
+
+
+global_engine = None
+
+
+def setUpModule():
+    """
+    Initialize the database.
+    """
+    global global_engine
+    global_engine = db_bootstrap()
+
+
+class NotifierTests(mocker.MockerTestCase):
+
+    def _makeOne(self, **kwargs):
+        checkpoint = kwargs.get('checkpoint', modelfactories.CheckpointFactory())
+        scieloapi = kwargs.get('scieloapi', doubles.ScieloAPIClientStub())
+        db_session = kwargs.get('db_session', doubles.SessionStub())
+
+        return Notifier(checkpoint, scieloapi, db_session)
+
+    def test_start_sends_notification_on_checkin_points(self):
+        checkpoint = modelfactories.CheckpointFactory(point=models.Point.checkin)
+        notifier = self._makeOne(checkpoint=checkpoint)
+
+        mock_notifier = self.mocker.patch(notifier)
+        mock_notifier._send_checkin_notification()
+        self.mocker.result(None)
+        self.mocker.replay()
+
+        notifier.start()
+
+    def test_start_doesnt_send_notification_otherwise(self):
+        checkpoint = modelfactories.CheckpointFactory(point=models.Point.validation)
+        notifier = self._makeOne(checkpoint=checkpoint)
+
+        mock_notifier = self.mocker.patch(notifier)
+        mock_notifier._send_checkin_notification()
+        self.mocker.result(None)
+        self.mocker.count(0,0)  # means the method is not called
+        self.mocker.replay()
+
+        notifier.start()
+
+    def test_send_checkin_notification_payload(self):
+        checkpoint = modelfactories.CheckpointFactory(point=models.Point.checkin)
+
+        expected = {
+             'articlepkg_ref': checkpoint.attempt.articlepkg.id,
+             'attempt_ref': checkpoint.attempt.id,
+             'article_title': checkpoint.attempt.articlepkg.article_title,
+             'journal_title': checkpoint.attempt.articlepkg.journal_title,
+             'issue_label': '##',
+             'package_name': checkpoint.attempt.filepath,
+             'uploaded_at': checkpoint.attempt.started_at,
+        }
+
+        mock_scieloapi = self.mocker.mock()
+        mock_scieloapi.checkins.post(expected)
+        self.mocker.result(None)
+        self.mocker.replay()
+
+        notifier = self._makeOne(checkpoint=checkpoint, scieloapi=mock_scieloapi)
+        self.assertIsNone(notifier._send_checkin_notification())
+

--- a/config-TEMPLATE.ini
+++ b/config-TEMPLATE.ini
@@ -11,6 +11,7 @@ recursive=True
 api_key=
 api_username=
 api_url=http://manager.scielo.org/api/v1/
+notifications=False
 
 [http_server]
 ip=0.0.0.0


### PR DESCRIPTION
O envio é disparado quando o método `Notifier.start` é invocado em objetos vinculados a checkpoints tipo `checkin`.
