### PR TITLE
Melhorias na comunicação entre módulos monitor e validator para facilitar o uso de unix domain sockets

### DIFF
--- a/balaio/balaio.py
+++ b/balaio/balaio.py
@@ -6,6 +6,7 @@ import subprocess
 import atexit
 import time
 import logging
+import socket
 
 import utils
 import models
@@ -70,8 +71,10 @@ def main():
     """
     Set up the processes and run indefinitely.
     """
-    monitor = run_monitor()
-    validator = run_validator(stdin=monitor.stdout)
+    sock_one, sock_two = socket.socketpair()
+
+    monitor = run_monitor(stdout=sock_one)
+    validator = run_validator(stdin=sock_two)
 
     procs = [monitor, validator]
 

--- a/balaio/balaio.py
+++ b/balaio/balaio.py
@@ -71,10 +71,8 @@ def main():
     """
     Set up the processes and run indefinitely.
     """
-    sock_one, sock_two = socket.socketpair()
-
-    monitor = run_monitor(stdout=sock_one)
-    validator = run_validator(stdin=sock_two)
+    monitor = run_monitor()
+    validator = run_validator()
 
     procs = [monitor, validator]
 

--- a/balaio/validator.py
+++ b/balaio/validator.py
@@ -589,8 +589,9 @@ class ArticleMetaPubDateValidationPipe(vpipes.ValidationPipe):
 if __name__ == '__main__':
     utils.setup_logging()
     config = utils.Configuration.from_env()
+    input_stream = utils.get_readable_socket()
 
-    messages = utils.recv_messages(sys.stdin, utils.make_digest)
+    messages = utils.recv_messages(input_stream, utils.make_digest)
     scieloapi = scieloapi.Client(config.get('manager', 'api_username'),
                                  config.get('manager', 'api_key'))
 


### PR DESCRIPTION
Esse PR não resolve o problema de os processos `monitor.py` e `validator.py` segurarem os fds stdin e stdout, mas abre espaço para uma nova abordagem de comunicação entre processos.
