### PR TITLE
Adicionar o pissn e o eissn no send_checkin do Balaio

### DIFF
--- a/balaio/monitor.py
+++ b/balaio/monitor.py
@@ -1,9 +1,9 @@
 #coding: utf-8
 import os
+import time
 import threading
 import Queue
 import logging
-import sys
 import zipfile
 import socket
 
@@ -38,7 +38,7 @@ class Monitor(object):
             try:
                 self.stream = utils.get_writable_socket(config.get('app', 'socket'))
                 break
-            except socket.error as e:
+            except socket.error:
                 logger.info('Trying to estabilish connection with module `validator`. Please wait...')
                 time.sleep(0.5)
             else:
@@ -74,6 +74,7 @@ class Monitor(object):
                     logger.debug('The file is gone before marked as duplicated. %s' % e)
 
             else:
+                #Send stream
                 utils.send_message(self.stream, attempt, utils.make_digest)
                 logging.debug('Message sent for %s: %s, %s' % (filepath,
                     repr(attempt), repr(utils.make_digest)))

--- a/balaio/notifier.py
+++ b/balaio/notifier.py
@@ -93,6 +93,8 @@ class Notifier(object):
                  'journal_title': self.checkpoint.attempt.articlepkg.journal_title,
                  'issue_label': '##',
                  'package_name': self.checkpoint.attempt.filepath,
+                 'pissn': self.checkpoint.attempt.articlepkg.journal_pissn,
+                 'eissn': self.checkpoint.attempt.articlepkg.journal_eissn,
                  'uploaded_at': str(self.checkpoint.attempt.started_at),
                }
         resource_uri = '/api/v1/checkins/%s/'

--- a/balaio/tests/test_notifier.py
+++ b/balaio/tests/test_notifier.py
@@ -61,6 +61,8 @@ class NotifierTests(mocker.MockerTestCase):
              'journal_title': checkpoint.attempt.articlepkg.journal_title,
              'issue_label': '##',
              'package_name': checkpoint.attempt.filepath,
+             'pissn': checkpoint.attempt.articlepkg.journal_pissn,
+             'eissn': checkpoint.attempt.articlepkg.journal_eissn,
              'uploaded_at': str(checkpoint.attempt.started_at),
         }
 


### PR DESCRIPTION
Adicionado o `pissn` e o `eissn` para envio no endpoint  `checkins`.
