### PR TITLE
Fixes #186. Zeros não significativos são excluídos de volume e número

### DIFF
--- a/balaio/tests/test_utils.py
+++ b/balaio/tests/test_utils.py
@@ -504,6 +504,12 @@ class IssueIdentificationTests(unittest.TestCase):
     def test_issue_identification_number_and_suppl(self):
         self.assertEqual(utils.issue_identification(None, '4', '2'), (None, None, '4', '2'))
 
+    def test_number_is_lstripped(self):
+        self.assertEqual(utils.issue_identification(None, '01', None), (None, None, '1', None))
+
+    def test_volume_is_lstripped(self):
+        self.assertEqual(utils.issue_identification('031', None, None), ('31', None, None, None))
+
 
 class RemoveUnixSocketTests(unittest.TestCase):
 

--- a/balaio/utils.py
+++ b/balaio/utils.py
@@ -380,12 +380,17 @@ def issue_identification(volume, number, supplement):
     """
     # issue can have contents like: 2, Suppl, 3 Suppl 1, Suppl 1
     number, label, suppl = parse_issue_tag(number)
-    if label:
-        if not suppl:
-            suppl = label
+    if label and not suppl:
+        suppl = label
     else:
         suppl = supplement
     volume_suppl, number_suppl = supplement_type(volume, number, suppl)
+
+    if volume is not None:
+        volume = volume.lstrip('0')
+
+    if number is not None:
+        number = number.lstrip('0')
 
     return (volume, volume_suppl, number, number_suppl)
 


### PR DESCRIPTION
Este PR está relacionado com o ticket do Manager: https://github.com/scieloorg/SciELO-Manager/issues/578
