### PR TITLE
Meta extractor - Módulo para geração do JSON-OPAC

### DIFF
--- a/balaio/meta_extractor.py
+++ b/balaio/meta_extractor.py
@@ -34,8 +34,10 @@ class AbbrevJournalTitlePipe(plumber.Pipe):
     def transform(self, item):
         xml, dict_data = item
 
-        if xml.findtext('.//journal-title-group/abbrev-journal-title[@abbrev-type="publisher"]') is not None:
-            dict_data['abbrev-journal-title'] = xml.findtext('.//abbrev-journal-title[@abbrev-type="publisher"]')
+        abbrev_journal_title = xml.findtext('.//journal-title-group/abbrev-journal-title[@abbrev-type="publisher"]')
+
+        if abbrev_journal_title is not None:
+            dict_data['abbrev-journal-title'] = abbrev_journal_title
 
         return (xml, dict_data)
 
@@ -47,7 +49,7 @@ class AbstractPipe(plumber.Pipe):
         xml, dict_data = item
         abstract_group = xml.find('.//article-meta')
 
-        if  xml.find('.//article-meta/abstract') is not None:
+        if xml.find('.//article-meta/abstract') is not None:
             abstracts[abstract_group.find('.//abstract').attrib.get('{http://www.w3.org/XML/1998/namespace}lang')] = abstract_group.findtext('.//abstract').strip()
 
         for trans_abstract in abstract_group.findall('.//trans-abstract'):
@@ -62,10 +64,11 @@ class JournalIDPipe(plumber.Pipe):
 
     def transform(self, item):
         xml, dict_data = item
-        journal_meta = xml.find('.//journal-meta')
 
-        if xml.find('.//journal-meta/journal-id[@journal-id-type="nlm-ta"]') is not None:
-            dict_data['journal-id'] = journal_meta.find('.//journal-id[@journal-id-type="nlm-ta"]').text
+        journal_id = xml.find('.//journal-meta/journal-id[@journal-id-type="nlm-ta"]')
+
+        if journal_id is not None:
+            dict_data['journal-id'] = journal_id.text
 
         return (xml, dict_data)
 
@@ -74,10 +77,10 @@ class LpagePipe(plumber.Pipe):
 
     def transform(self, item):
         xml, dict_data = item
-        article_meta = xml.find('.//article-meta')
+        lpage = xml.find('.//article-meta/lpage')
 
-        if xml.find('.//article-meta/lpage') is not None:
-            dict_data['lpage'] = article_meta.findtext('.//lpage')
+        if lpage is not None:
+            dict_data['lpage'] = lpage.text
 
         return (xml, dict_data)
 
@@ -86,10 +89,10 @@ class FpagePipe(plumber.Pipe):
 
     def transform(self, item):
         xml, dict_data = item
-        article_meta = xml.find('.//article-meta')
+        fpage = xml.find('.//article-meta/fpage')
 
-        if xml.find('.//article-meta/fpage') is not None:
-            dict_data['fpage'] = article_meta.findtext('.//fpage')
+        if fpage is not None:
+            dict_data['fpage'] = fpage.text
 
         return (xml, dict_data)
 
@@ -98,10 +101,10 @@ class JournalTitlePipe(plumber.Pipe):
 
     def transform(self, item):
         xml, dict_data = item
-        journal_title_group = xml.find('.//journal-title-group')
+        journal_title = xml.find('.//journal-title-group/journal-title')
 
-        if xml.find('.//journal-title-group/journal-title') is not None:
-            dict_data['journal-title'] = journal_title_group.findtext('journal-title')
+        if journal_title is not None:
+            dict_data['journal-title'] = journal_title.text
 
         return (xml, dict_data)
 
@@ -113,9 +116,8 @@ class AuthorPipe(plumber.Pipe):
         list_author = []
 
         xml, dict_data = item
-        contrib_group = xml.find('.//contrib-group')
 
-        for contrib in contrib_group.findall('.//contrib[@contrib-type="author"]'):
+        for contrib in xml.findall('.//contrib-group/contrib[@contrib-type="author"]'):
             list_author.append({'given-names':contrib.findtext('.//given-names'),
                                 'surname':contrib.findtext('.//surname'),
                                 'affiliations':[ref.attrib['rid'] for ref in contrib.findall('.//xref') if ref is not None]})
@@ -133,18 +135,24 @@ class AffiliationPipe(plumber.Pipe):
 
         xml, dict_data = item
 
-        if xml.findall('.//article-meta/aff') is not None:
-            for aff in xml.findall('.//article-meta/aff'):
+        affiliations = xml.findall('.//article-meta/aff')
+
+        if affiliations is not None:
+
+            for aff in affiliations:
+                ref_id = aff.get('id')
+                institution = aff.findtext('.//institution[@content-type="orgname"]')
+                country = aff.findtext('.//country')
                 dict_aff = {}
 
-                if aff.findtext('.//institution[@content-type="orgname"]'):
-                    dict_aff['institution'] = aff.findtext('.//institution[@content-type="orgname"]')
+                if institution:
+                    dict_aff['institution'] = institution
 
-                if aff.get('id'):
-                    dict_aff['ref'] =  aff.get('id')
+                if ref_id:
+                    dict_aff['ref'] = ref_id
 
-                if aff.findtext('.//country'):
-                    dict_aff['country'] =  aff.findtext('.//country')
+                if country:
+                    dict_aff['country'] = country
 
                 list_aff.append(dict_aff)
 
@@ -182,10 +190,10 @@ class VolumePipe(plumber.Pipe):
 
     def transform(self, item):
         xml, dict_data = item
-        article_meta = xml.find('.//article-meta')
+        volume = xml.find('.//article-meta/volume')
 
-        if article_meta.find('.//volume') is not None:
-            dict_data['volume'] = article_meta.findtext('.//volume')
+        if volume is not None:
+            dict_data['volume'] = volume.text
 
         return (xml, dict_data)
 
@@ -194,10 +202,10 @@ class NumberPipe(plumber.Pipe):
 
     def transform(self, item):
         xml, dict_data = item
-        article_meta = xml.find('.//article-meta')
+        number = xml.find('.//article-meta/issue')
 
-        if article_meta.find('.//issue') is not None:
-            dict_data['number'] = article_meta.findtext('.//issue')
+        if number is not None:
+            dict_data['number'] = number.text
 
         return (xml, dict_data)
 
@@ -221,10 +229,10 @@ class ISSNPipe(plumber.Pipe):
 
     def transform(self, item):
         xml, dict_data = item
-        article_meta = xml.find('.//journal-meta')
+        issn = xml.find('.//journal-meta/issn[@pub-type="epub"]')
 
-        if article_meta.find('.//issn[@pub-type="epub"]') is not None:
-            dict_data['issn'] = article_meta.findtext('.//issn[@pub-type="epub"]')
+        if issn is not None:
+            dict_data['issn'] = issn.text
 
         return (xml, dict_data)
 
@@ -233,10 +241,10 @@ class PublisherNamePipe(plumber.Pipe):
 
     def transform(self, item):
         xml, dict_data = item
-        article_meta = xml.find('.//journal-meta')
+        publisher_name = xml.find('.//journal-meta/publisher/publisher-name')
 
-        if article_meta.find('.//publisher/publisher-name') is not None:
-            dict_data['publisher-name'] = article_meta.findtext('.//publisher/publisher-name')
+        if publisher_name is not None:
+            dict_data['publisher-name'] = publisher_name.text
 
         return (xml, dict_data)
 
@@ -246,9 +254,8 @@ class SubjectPipe(plumber.Pipe):
     def transform(slef, item):
         subjects = {}
         xml, dict_data = item
-        subject_group = xml.findall('.//article-meta/article-categories/subj-group')
 
-        for sub_subject in subject_group:
+        for sub_subject in xml.findall('.//article-meta/article-categories/subj-group'):
             if sub_subject.get('subj-group-type'):
                 subjects[sub_subject.attrib['subj-group-type']] = [subject.text for subject in sub_subject if subject.text]
 
@@ -262,9 +269,8 @@ class PublisherIDPipe(plumber.Pipe):
     def transform(self, item):
         article_ids = {}
         xml, dict_data = item
-        article_meta = xml.find('.//article-meta')
 
-        for article_id in article_meta.findall('.//article-id'):
+        for article_id in xml.findall('.//article-meta/article-id'):
             if article_id.get('pub-id-type') and article_id.text:
                 article_ids[article_id.get('pub-id-type')] = article_id.text
 
@@ -302,7 +308,7 @@ if __name__ == '__main__':
                            PublisherIDPipe(),
                            TearDownPipe())
 
-    xml = etree.parse(open('0034-8910-rsp-47-04-0647.xml', 'rb'))
+    xml = etree.parse(open('<FILELIKEOBJECT>', 'rb'))
     data = ppl.run([xml])
 
     for dt in data:

--- a/balaio/meta_extractor.py
+++ b/balaio/meta_extractor.py
@@ -1,0 +1,285 @@
+# coding: utf-8
+
+import json
+from lxml import etree
+
+import plumber
+
+
+class SetupPipe(plumber.Pipe):
+
+    def transform(self, xml):
+        return (xml, {})
+
+
+class TitlePipe(plumber.Pipe):
+
+    def transform(self, item):
+        titles = {}
+        xml, dict_data = item
+        title_group = xml.find('.//title-group')
+
+        titles[title_group.find('article-title').attrib.get('{http://www.w3.org/XML/1998/namespace}lang')] = title_group.findtext('article-title')
+
+        for trans_title in title_group.findall('.//trans-title-group'):
+            titles[trans_title.attrib.get('{http://www.w3.org/XML/1998/namespace}lang')] = trans_title.findtext('trans-title')
+
+        dict_data['title-group'] = titles
+
+        return (xml, dict_data)
+
+
+class AbbrevJournalTitlePipe(plumber.Pipe):
+
+    def transform(self, item):
+        xml, dict_data = item
+        journal_title_group = xml.find('.//journal-title-group')
+
+        dict_data['abbrev-journal-title'] = journal_title_group.findtext('.//abbrev-journal-title[@abbrev-type="publisher"]')
+
+        return (xml, dict_data)
+
+
+class AbstractPipe(plumber.Pipe):
+
+    def transform(self, item):
+        abstracts = {}
+        xml, dict_data = item
+        abstract_group = xml.find('.//article-meta')
+
+        abstracts[abstract_group.find('.//abstract').attrib.get('{http://www.w3.org/XML/1998/namespace}lang')] = abstract_group.findtext('.//abstract')
+
+        for trans_abstract in abstract_group.findall('.//trans-abstract'):
+            abstracts[trans_abstract.attrib.get('{http://www.w3.org/XML/1998/namespace}lang')] = trans_abstract.text
+
+        dict_data['abstract'] = abstracts
+
+        return (xml, dict_data)
+
+
+class JournalIDPipe(plumber.Pipe):
+
+    def transform(self, item):
+        xml, dict_data = item
+        journal_meta = xml.find('.//journal-meta')
+
+        dict_data['journal-id'] = journal_meta.find('.//journal-id[@journal-id-type="nlm-ta"]').text
+
+        return (xml, dict_data)
+
+
+class LpagePipe(plumber.Pipe):
+
+    def transform(self, item):
+        xml, dict_data = item
+        article_meta = xml.find('.//article-meta')
+
+        dict_data['lpage'] = article_meta.findtext('.//lpage')
+
+        return (xml, dict_data)
+
+
+class FpagePipe(plumber.Pipe):
+
+    def transform(self, item):
+        xml, dict_data = item
+        article_meta = xml.find('.//article-meta')
+
+        dict_data['fpage'] = article_meta.findtext('.//fpage')
+
+        return (xml, dict_data)
+
+
+class JournalTitlePipe(plumber.Pipe):
+
+    def transform(self, item):
+        xml, dict_data = item
+        journal_title_group = xml.find('.//journal-title-group')
+
+        dict_data['journal-title'] = journal_title_group.findtext('journal-title')
+
+        return (xml, dict_data)
+
+
+class AuthorPipe(plumber.Pipe):
+
+    def transform(self, item):
+        contribs = {}
+        list_author = []
+
+        xml, dict_data = item
+        contrib_group = xml.find('.//contrib-group')
+
+        for contrib in contrib_group.findall('.//contrib[@contrib-type="author"]'):
+            list_author.append({'given-names':contrib.findtext('.//surname'),
+                                'surname':contrib.findtext('.//given-names'),
+                                'affiliations':[ref.attrib['rid'] for ref in contrib.findall('.//xref')]})
+
+        contribs['authors'] = list_author
+        dict_data['contrib-group'] = contribs
+
+        return (xml, dict_data)
+
+
+class AffiliationPipe(plumber.Pipe):
+
+    def transform(self, item):
+        list_aff = []
+
+        xml, dict_data = item
+
+        for aff in xml.findall('.//article-meta/aff'):
+            list_aff.append({'ref': aff.attrib['id'],
+                             'institution': aff.findtext('../institution[@content-type="orgname"]'),
+                             'country': aff.findtext('./country')})
+
+        dict_data['affiliations'] = list_aff
+
+        return (xml, dict_data)
+
+
+class KeywordPipe(plumber.Pipe):
+
+    def transform(self, item):
+        keywords = {}
+        xml, dict_data = item
+
+        for kwd in xml.findall('.//article-meta/kwd-group'):
+            keywords[kwd.attrib.get('{http://www.w3.org/XML/1998/namespace}lang')] = [k.text for k in kwd.findall('.//kwd')]
+
+        dict_data['keyword-group'] = keywords
+
+        return (xml, dict_data)
+
+
+class DefaultLanguagePipe(plumber.Pipe):
+
+    def transform(self, item):
+        xml, dict_data = item
+
+        dict_data['default-language'] = xml.getroot().attrib.get('{http://www.w3.org/XML/1998/namespace}lang')
+
+        return (xml, dict_data)
+
+class VolumePipe(plumber.Pipe):
+
+    def transform(self, item):
+        xml, dict_data = item
+        article_meta = xml.find('.//article-meta')
+
+        dict_data['volume'] = article_meta.findtext('.//volume')
+
+        return (xml, dict_data)
+
+
+class NumberPipe(plumber.Pipe):
+
+    def transform(self, item):
+        xml, dict_data = item
+        article_meta = xml.find('.//article-meta')
+
+        dict_data['number'] = article_meta.findtext('.//issue')
+
+        return (xml, dict_data)
+
+
+class PubDatePipe(plumber.Pipe):
+
+    def transform(self, item):
+        dates = {}
+        xml, dict_data = item
+
+        for date in xml.findall('.//pub-date/'):
+            dates[date.tag] = date.text
+
+        dict_data['pub-date'] = dates
+
+        return (xml, dict_data)
+
+
+class ISSNPipe(plumber.Pipe):
+
+    def transform(self, item):
+        xml, dict_data = item
+        article_meta = xml.find('.//journal-meta')
+
+        dict_data['issn'] = article_meta.findtext('.//issn[@pub-type="epub"]')
+
+        return (xml, dict_data)
+
+
+class PublisherNamePipe(plumber.Pipe):
+
+    def transform(self, item):
+        xml, dict_data = item
+        article_meta = xml.find('.//journal-meta')
+
+        dict_data['publisher-name'] = article_meta.findtext('.//publisher/publisher-name')
+
+        return (xml, dict_data)
+
+
+class SubjectPipe(plumber.Pipe):
+
+    def transform(slef, item):
+        subjects = {}
+        xml, dict_data = item
+        subject_group = xml.findall('.//article-meta/article-categories/subj-group')
+
+        for sub_subject in subject_group:
+            subjects[sub_subject.attrib['subj-group-type']] = [subject.text for subject in sub_subject]
+
+        dict_data['subjects'] = subjects
+
+        return (xml, dict_data)
+
+
+class PublisherIDPipe(plumber.Pipe):
+
+    def transform(self, item):
+        article_ids = {}
+        xml, dict_data = item
+        article_meta = xml.find('.//article-meta')
+
+        for article_id in article_meta.findall('.//article-id'):
+            article_ids[article_id.attrib['pub-id-type']] = article_id.text
+
+        dict_data['article-ids'] = article_ids
+
+        return (xml, dict_data)
+
+
+class TearDownPipe(plumber.Pipe):
+
+    def transform(self, item):
+        xml, dict_data = item
+        return json.dumps(dict_data, indent=2)
+
+
+if __name__ == '__main__':
+    ppl = plumber.Pipeline(SetupPipe(),
+                           TitlePipe(),
+                           AbbrevJournalTitlePipe(),
+                           AbstractPipe(),
+                           JournalIDPipe(),
+                           AuthorPipe(),
+                           AffiliationPipe(),
+                           KeywordPipe(),
+                           DefaultLanguagePipe(),
+                           LpagePipe(),
+                           FpagePipe(),
+                           JournalTitlePipe(),
+                           VolumePipe(),
+                           NumberPipe(),
+                           PubDatePipe(),
+                           ISSNPipe(),
+                           PublisherNamePipe(),
+                           SubjectPipe(),
+                           PublisherIDPipe(),
+                           TearDownPipe())
+
+    xml = etree.parse(open('0034-8910-rsp-47-04-0647.xml', 'rb'))
+    transformed_data = ppl.run([xml])
+
+    for td in transformed_data:
+        print td

--- a/balaio/tests/test_meta_extractor.py
+++ b/balaio/tests/test_meta_extractor.py
@@ -554,6 +554,7 @@ class AuthorPipeTest(unittest.TestCase):
 
         self.assertEqual(dict_data, expected)
 
+
 class AffiliationPipeTest(unittest.TestCase):
 
     def test_if_affiliation_pipe_return_correct_dict(self):
@@ -601,103 +602,643 @@ class AffiliationPipeTest(unittest.TestCase):
 
         self.assertEqual(dict_data, expected)
 
-    # def test_if_author_title_pipe_treats_the_absent_of_contrib(self):
-    #     xml_str = '''
-    #           <article>
-    #             <journal-meta>
-    #               <contrib-group>
-    #                   <name>
-    #                     <surname>Soysal</surname>
-    #                     <given-names>Ahmet</given-names>
-    #                   </name>
-    #                   <xref ref-type="aff" rid="aff1">
-    #                     <sup>I</sup>
-    #                   </xref>
-    #                 <contrib contrib-type="author">
-    #                   <name>
-    #                     <surname>Simsek</surname>
-    #                     <given-names>Hatice</given-names>
-    #                   </name>
-    #                   <xref ref-type="aff" rid="aff1">
-    #                     <sup>I</sup>
-    #                   </xref>
-    #                 </contrib>
-    #               </contrib-group>
-    #             </journal-meta>
-    #           </article>'''
+    def test_if_affiliation_pipe_treats_the_absent_of_institution(self):
+        xml_str = '''
+            <article>
+                <article-meta>
+                <aff id="aff1">
+                    <addr-line>
+                    <named-content content-type="city">Sao Paulo</named-content>
+                    <named-content content-type="state">SP</named-content>
+                    </addr-line>
+                    <country>Brasil</country>
+                </aff>
+                <aff id="aff2">
+                    <institution content-type="orgname">Universidade de Sao Paulo</institution>
+                    <addr-line>
+                    <named-content content-type="city">Sao Paulo</named-content>
+                    <named-content content-type="state">SP</named-content>
+                    </addr-line>
+                    <country>Brasil</country>
+                </aff>
+                </article-meta>
+            </article>'''
 
-    #     xml = etree.parse(StringIO(xml_str))
+        xml = etree.parse(StringIO(xml_str))
 
-    #     expected = {
-    #             "contrib-group": {
-    #               "authors": [
-    #                 {
-    #                   "given-names": "Hatice",
-    #                   "surname": "Simsek",
-    #                   "affiliations": [
-    #                     "aff1"
-    #                   ]
-    #                 }]
-    #               }
-    #             }
+        expected = {
+              "affiliations": [
+                {
+                  "ref": "aff1",
+                  "country": "Brasil"
+                },
+                {
+                  "ref": "aff2",
+                  "institution": "Universidade de Sao Paulo",
+                  "country": "Brasil"
+                },
+              ],
+            }
 
-    #     mta_extractor = meta_extractor.AuthorPipe()
-    #     xml, dict_data = mta_extractor.transform([xml, {}])
+        mta_extractor = meta_extractor.AffiliationPipe()
+        xml, dict_data = mta_extractor.transform([xml, {}])
 
-    #     self.assertEqual(dict_data, expected)
+        self.assertEqual(dict_data, expected)
 
-    # def test_if_author_title_pipe_treats_the_absent_of_any_ref(self):
-    #     xml_str = '''
-    #         <article>
-    #             <journal-meta>
-    #               <contrib-group>
-    #                 <contrib contrib-type="author">
-    #                   <name>
-    #                     <surname>Soysal</surname>
-    #                     <given-names>Ahmet</given-names>
-    #                   </name>
-    #                 </contrib>
-    #                 <contrib contrib-type="author">
-    #                   <name>
-    #                     <surname>Simsek</surname>
-    #                     <given-names>Hatice</given-names>
-    #                   </name>
-    #                   <xref ref-type="aff" rid="aff1">
-    #                     <sup>I</sup>
-    #                   </xref>
-    #                 </contrib>
-    #               </contrib-group>
-    #             </journal-meta>
-    #         </article>'''
+    def test_if_affiliation_pipe_treats_the_absent_of_country(self):
+        xml_str = '''
+            <article>
+                <article-meta>
+                <aff id="aff1">
+                    <institution content-type="orgname">Santa Casa de Sao Paulo</institution>
+                    <addr-line>
+                    <named-content content-type="city">Sao Paulo</named-content>
+                    <named-content content-type="state">SP</named-content>
+                    </addr-line>
+                </aff>
+                <aff id="aff2">
+                    <institution content-type="orgname">Universidade de Sao Paulo</institution>
+                    <addr-line>
+                    <named-content content-type="city">Sao Paulo</named-content>
+                    <named-content content-type="state">SP</named-content>
+                    </addr-line>
+                    <country>Brasil</country>
+                </aff>
+                </article-meta>
+            </article>'''
 
-    #     xml = etree.parse(StringIO(xml_str))
+        xml = etree.parse(StringIO(xml_str))
 
-    #     expected = {
-    #             "contrib-group": {
-    #               "authors": [
-    #                 {
-    #                   "given-names": "Ahmet",
-    #                   "surname": "Soysal",
-    #                   "affiliations": []
-    #                 },
-    #                 {
-    #                   "given-names": "Hatice",
-    #                   "surname": "Simsek",
-    #                   "affiliations": [
-    #                     "aff1"
-    #                   ]
-    #                 }]
-    #               }
-    #             }
+        expected = {
+              "affiliations": [
+                {
+                  "ref": "aff1",
+                  "institution": "Santa Casa de Sao Paulo",
+                },
+                {
+                  "ref": "aff2",
+                  "institution": "Universidade de Sao Paulo",
+                  "country": "Brasil"
+                },
+              ],
+            }
 
-    #     mta_extractor = meta_extractor.AuthorPipe()
-    #     xml, dict_data = mta_extractor.transform([xml, {}])
+        mta_extractor = meta_extractor.AffiliationPipe()
+        xml, dict_data = mta_extractor.transform([xml, {}])
 
-    #     self.assertEqual(dict_data, expected)
+        self.assertEqual(dict_data, expected)
+
+    def test_if_affiliation_pipe_treats_the_absent_of_named_content_city(self):
+        xml_str = '''
+            <article>
+                <article-meta>
+                <aff id="aff1">
+                    <institution content-type="orgname">Santa Casa de Sao Paulo</institution>
+                    <addr-line>
+                    <named-content content-type="state">SP</named-content>
+                    </addr-line>
+                    <country>Brasil</country>
+                </aff>
+                <aff id="aff2">
+                    <institution content-type="orgname">Universidade de Sao Paulo</institution>
+                    <addr-line>
+                    <named-content content-type="city">Sao Paulo</named-content>
+                    </addr-line>
+                    <country>Brasil</country>
+                </aff>
+                </article-meta>
+            </article>'''
+
+        xml = etree.parse(StringIO(xml_str))
+
+        expected = {
+              "affiliations": [
+                {
+                  "ref": "aff1",
+                  "institution": "Santa Casa de Sao Paulo",
+                  "country": "Brasil"
+                },
+                {
+                  "ref": "aff2",
+                  "institution": "Universidade de Sao Paulo",
+                  "country": "Brasil"
+                },
+              ],
+            }
+
+        mta_extractor = meta_extractor.AffiliationPipe()
+        xml, dict_data = mta_extractor.transform([xml, {}])
+
+        self.assertEqual(dict_data, expected)
+
+    def test_if_affiliation_pipe_treats_the_absent_of_ref_id(self):
+        xml_str = '''
+            <article>
+                <article-meta>
+                <aff id="aff1">
+                    <institution content-type="orgname">Santa Casa de Sao Paulo</institution>
+                    <addr-line>
+                    <named-content content-type="state">SP</named-content>
+                    </addr-line>
+                    <country>Brasil</country>
+                </aff>
+                <aff>
+                    <institution content-type="orgname">Universidade de Sao Paulo</institution>
+                    <addr-line>
+                    <named-content content-type="city">Sao Paulo</named-content>
+                    </addr-line>
+                    <country>Brasil</country>
+                </aff>
+                </article-meta>
+            </article>'''
+
+        xml = etree.parse(StringIO(xml_str))
+
+        expected = {
+              "affiliations": [
+                {
+                  "ref": "aff1",
+                  "institution": "Santa Casa de Sao Paulo",
+                  "country": "Brasil"
+                },
+                {
+                  "institution": "Universidade de Sao Paulo",
+                  "country": "Brasil"
+                },
+              ],
+            }
+
+        mta_extractor = meta_extractor.AffiliationPipe()
+        xml, dict_data = mta_extractor.transform([xml, {}])
+
+        self.assertEqual(dict_data, expected)
 
 
+class KeywordPipeTest(unittest.TestCase):
+
+    def test_if_keyword_pipe_return_correct_dict(self):
+            xml_str = '''
+                <article>
+                  <article-meta>
+                    <kwd-group xml:lang="en">
+                        <kwd>health-care waste</kwd>
+                        <kwd>waste management</kwd>
+                    </kwd-group>
+                    <kwd-group xml:lang="pt">
+                        <kwd>rifiuti sanitari</kwd>
+                        <kwd>Uso de Medicamentos</kwd>
+                    </kwd-group>
+                  </article-meta>
+                </article>'''
+
+            xml = etree.parse(StringIO(xml_str))
+
+            expected = {
+                "keyword-group": {
+                        "en": [
+                            "health-care waste",
+                            "waste management"
+                        ],
+                        "pt": [
+                            "rifiuti sanitari",
+                            "Uso de Medicamentos",
+                        ],
+                    }
+                }
+
+            mta_extractor = meta_extractor.KeywordPipe()
+            xml, dict_data = mta_extractor.transform([xml, {}])
+
+            self.assertEqual(dict_data, expected)
+
+    def test_if_affiliation_pipe_treats_the_absent_of_kwd(self):
+            xml_str = '''
+                <article>
+                  <article-meta>
+                    <kwd-group xml:lang="en">
+                        <kwd></kwd>
+                        <kwd>waste management</kwd>
+                    </kwd-group>
+                    <kwd-group xml:lang="pt">
+                        <kwd>rifiuti sanitari</kwd>
+                        <kwd>Uso de Medicamentos</kwd>
+                    </kwd-group>
+                  </article-meta>
+                </article>'''
+
+            xml = etree.parse(StringIO(xml_str))
+
+            expected = {
+                "keyword-group": {
+                        "en": [
+                            "waste management"
+                        ],
+                        "pt": [
+                            "rifiuti sanitari",
+                            "Uso de Medicamentos",
+                        ],
+                    }
+                }
+
+            mta_extractor = meta_extractor.KeywordPipe()
+            xml, dict_data = mta_extractor.transform([xml, {}])
+
+            self.assertEqual(dict_data, expected)
 
 
+class DefaultLanguagePipeTest(unittest.TestCase):
+
+    def test_if_default_language_pipe_return_correct_dict(self):
+        xml_str = '''
+                <article xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" dtd-version="3.0" article-type="research-article" xml:lang="pt">
+                </article>
+                  '''
+
+        xml = etree.parse(StringIO(xml_str))
+
+        expected = {
+            "default-language": "pt",
+            }
+
+        mta_extractor = meta_extractor.DefaultLanguagePipe()
+        xml, dict_data = mta_extractor.transform([xml, {}])
+
+        self.assertEqual(dict_data, expected)
 
 
+    def test_default_language_pipe_without_default_language(self):
+        xml_str = '''
+                <article xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" dtd-version="3.0" article-type="research-article">
+                </article>
+                  '''
+
+        xml = etree.parse(StringIO(xml_str))
+
+        expected = {
+            }
+
+        mta_extractor = meta_extractor.DefaultLanguagePipe()
+        xml, dict_data = mta_extractor.transform([xml, {}])
+
+        self.assertEqual(dict_data, expected)
+
+
+class VolumePipeTest(unittest.TestCase):
+
+    def test_if_volume_pipe_return_correct_dict(self):
+        xml_str = '''
+            <article>
+              <article-meta>
+                <volume>47</volume>
+              </article-meta>
+            </article>'''
+
+        xml = etree.parse(StringIO(xml_str))
+
+        expected = {
+            "volume": "47",
+            }
+
+        mta_extractor = meta_extractor.VolumePipe()
+        xml, dict_data = mta_extractor.transform([xml, {}])
+
+        self.assertEqual(dict_data, expected)
+
+    def test_volume_pipe_without_default_language(self):
+        xml_str = '''
+            <article>
+              <article-meta>
+              </article-meta>
+            </article>'''
+
+        xml = etree.parse(StringIO(xml_str))
+
+        expected = {}
+
+        mta_extractor = meta_extractor.VolumePipe()
+        xml, dict_data = mta_extractor.transform([xml, {}])
+
+        self.assertEqual(dict_data, expected)
+
+
+class NumberPipeTest(unittest.TestCase):
+
+    def test_if_number_pipe_return_correct_dict(self):
+        xml_str = '''
+            <article>
+              <article-meta>
+                <issue>47</issue>
+              </article-meta>
+            </article>'''
+
+        xml = etree.parse(StringIO(xml_str))
+
+        expected = {
+            "number": "47",
+            }
+
+        mta_extractor = meta_extractor.NumberPipe()
+        xml, dict_data = mta_extractor.transform([xml, {}])
+
+        self.assertEqual(dict_data, expected)
+
+    def test_number_pipe_without_default_language(self):
+        xml_str = '''
+            <article>
+              <article-meta>
+              </article-meta>
+            </article>'''
+
+        xml = etree.parse(StringIO(xml_str))
+
+        expected = {}
+
+        mta_extractor = meta_extractor.NumberPipe()
+        xml, dict_data = mta_extractor.transform([xml, {}])
+
+        self.assertEqual(dict_data, expected)
+
+
+class PubDatePipeTest(unittest.TestCase):
+
+    def test_if_pub_date_pipe_return_correct_dict(self):
+        xml_str = '''
+            <article>
+              <article-meta>
+                <pub-date pub-type="ppub">
+                  <month>08</month>
+                  <year>2013</year>
+                </pub-date>
+              </article-meta>
+            </article>'''
+
+        xml = etree.parse(StringIO(xml_str))
+
+        expected = {
+            "pub-date": {
+                "month": "08",
+                "year": "2013"
+                },
+            }
+
+        mta_extractor = meta_extractor.PubDatePipe()
+        xml, dict_data = mta_extractor.transform([xml, {}])
+
+        self.assertEqual(dict_data, expected)
+
+    def test_if_pub_date_pipe_treats_the_absent_of_kwd(self):
+        xml_str = '''
+            <article>
+              <article-meta>
+                <pub-date pub-type="ppub">
+                  <year>2013</year>
+                </pub-date>
+              </article-meta>
+            </article>'''
+
+        xml = etree.parse(StringIO(xml_str))
+
+        expected = {
+            "pub-date": {
+                "year": "2013"
+                },
+            }
+
+        mta_extractor = meta_extractor.PubDatePipe()
+        xml, dict_data = mta_extractor.transform([xml, {}])
+
+        self.assertEqual(dict_data, expected)
+
+    def test_if_pub_date_pipe_treats_the_empty_child(self):
+            xml_str = '''
+                <article>
+                  <article-meta>
+                    <pub-date pub-type="ppub">
+                      <month>08</month>
+                      <year></year>
+                    </pub-date>
+                  </article-meta>
+                </article>'''
+
+            xml = etree.parse(StringIO(xml_str))
+
+            expected = {
+                "pub-date": {
+                    "month": "08"
+                    },
+                }
+
+            mta_extractor = meta_extractor.PubDatePipe()
+            xml, dict_data = mta_extractor.transform([xml, {}])
+
+            self.assertEqual(dict_data, expected)
+
+
+class ISSNPipeTest(unittest.TestCase):
+
+    def test_if_issn_pipe_return_correct_dict(self):
+        xml_str = '''
+            <article>
+              <journal-meta>
+                  <issn pub-type="epub">0034-8910</issn>
+              </journal-meta>
+            </article>'''
+
+        xml = etree.parse(StringIO(xml_str))
+
+        expected = {
+            "issn": "0034-8910"
+            }
+
+        mta_extractor = meta_extractor.ISSNPipe()
+        xml, dict_data = mta_extractor.transform([xml, {}])
+
+        self.assertEqual(dict_data, expected)
+
+    def test_if_pub_date_pipe_treats_the_absent_of_issn(self):
+        xml_str = '''
+            <article>
+              <journal-meta>
+              </journal-meta>
+            </article>'''
+
+        xml = etree.parse(StringIO(xml_str))
+
+        expected = {}
+
+        mta_extractor = meta_extractor.ISSNPipe()
+        xml, dict_data = mta_extractor.transform([xml, {}])
+
+        self.assertEqual(dict_data, expected)
+
+
+class PublisherNamePipeTest(unittest.TestCase):
+
+    def test_if_publihser_name_pipe_return_correct_dict(self):
+        xml_str = '''
+            <article>
+              <journal-meta>
+                <publisher>
+                  <publisher-name>Faculdade de Saude Publica da Universidade de Sao Paulo</publisher-name>
+                </publisher>
+              </journal-meta>
+            </article>'''
+
+        xml = etree.parse(StringIO(xml_str))
+
+        expected = {
+            "publisher-name": "Faculdade de Saude Publica da Universidade de Sao Paulo"
+            }
+
+        mta_extractor = meta_extractor.PublisherNamePipe()
+        xml, dict_data = mta_extractor.transform([xml, {}])
+
+        self.assertEqual(dict_data, expected)
+
+    def test_if_publisher_name_pipe_treats_the_absent_of_issn(self):
+        xml_str = '''
+            <article>
+              <journal-meta>
+                <publisher>
+                </publisher>
+              </journal-meta>
+            </article>'''
+
+        xml = etree.parse(StringIO(xml_str))
+
+        expected = {}
+
+        mta_extractor = meta_extractor.PublisherNamePipe()
+        xml, dict_data = mta_extractor.transform([xml, {}])
+
+        self.assertEqual(dict_data, expected)
+
+
+class SubjectPipeTest(unittest.TestCase):
+
+    def test_if_publisher_name_pipe_return_correct_dict(self):
+        xml_str = '''
+            <article>
+              <article-meta>
+                <article-categories>
+                  <subj-group subj-group-type="heading">
+                    <subject>Artigo Especial</subject>
+                    <subject>Outro</subject>
+                  </subj-group>
+                </article-categories>
+              </article-meta>
+            </article>'''
+
+        xml = etree.parse(StringIO(xml_str))
+
+        expected = {
+            "subjects": {
+                "heading": ["Artigo Especial", "Outro"]
+                }
+            }
+
+        mta_extractor = meta_extractor.SubjectPipe()
+        xml, dict_data = mta_extractor.transform([xml, {}])
+
+        self.assertEqual(dict_data, expected)
+
+    def test_if_subject_pipe_treats_the_absent_of_subject(self):
+        xml_str = '''
+            <article>
+              <article-meta>
+                <article-categories>
+                </article-categories>
+              </article-meta>
+            </article>'''
+
+        xml = etree.parse(StringIO(xml_str))
+
+        expected = {
+            "subjects": {}
+        }
+
+        mta_extractor = meta_extractor.SubjectPipe()
+        xml, dict_data = mta_extractor.transform([xml, {}])
+
+        self.assertEqual(dict_data, expected)
+
+
+class PublisherIDPipeTest(unittest.TestCase):
+
+    def test_if_publisher_id_pipe_return_correct_dict(self):
+        xml_str = '''
+            <article>
+              <article-meta>
+                <article-id pub-id-type="publisher-id">S0034-8910.2013047004396</article-id>
+                <article-id pub-id-type="doi">10.1590/S0034-8910.2013047004396</article-id>
+              </article-meta>
+            </article>'''
+
+        xml = etree.parse(StringIO(xml_str))
+
+        expected = {
+            "article-ids": {
+                "publisher-id": "S0034-8910.2013047004396",
+                "doi": "10.1590/S0034-8910.2013047004396"
+                }
+            }
+
+        mta_extractor = meta_extractor.PublisherIDPipe()
+        xml, dict_data = mta_extractor.transform([xml, {}])
+
+        self.assertEqual(dict_data, expected)
+
+    def test_if_publisher_id_pipe_treats_the_absent_of_article_id(self):
+        xml_str = '''
+            <article>
+              <article-meta>
+                <article-id pub-id-type="doi">10.1590/S0034-8910.2013047004396</article-id>
+              </article-meta>
+            </article>'''
+
+        xml = etree.parse(StringIO(xml_str))
+
+        expected = {
+            "article-ids": {
+                "doi": "10.1590/S0034-8910.2013047004396"
+                }
+            }
+
+        mta_extractor = meta_extractor.PublisherIDPipe()
+        xml, dict_data = mta_extractor.transform([xml, {}])
+
+        self.assertEqual(dict_data, expected)
+
+    def test_if_publisher_id_pipe_treats_the_empty_article_id(self):
+        xml_str = '''
+            <article>
+              <article-meta>
+                <article-id pub-id-type="doi"></article-id>
+              </article-meta>
+            </article>'''
+
+        xml = etree.parse(StringIO(xml_str))
+
+        expected = {
+            "article-ids": {
+                }
+            }
+
+        mta_extractor = meta_extractor.PublisherIDPipe()
+        xml, dict_data = mta_extractor.transform([xml, {}])
+
+        self.assertEqual(dict_data, expected)
+
+
+class TearDownPipeTest(unittest.TestCase):
+
+    def test_if_tear_down_return_str_type(self):
+        xml_str = '''<article></article>'''
+
+        xml = etree.parse(StringIO(xml_str))
+
+        mta_extractor = meta_extractor.TearDownPipe()
+        xml, dict_data = mta_extractor.transform([xml, {}])
+
+        self.assertIs(type(dict_data), str)
 

--- a/balaio/tests/test_meta_extractor.py
+++ b/balaio/tests/test_meta_extractor.py
@@ -1,0 +1,703 @@
+# coding: utf-8
+import unittest
+from lxml import etree
+from StringIO import StringIO
+
+from balaio import meta_extractor
+
+
+class SetupPipeTest(unittest.TestCase):
+
+    def test_if_setup_return_xml_dict(self):
+        xml = None
+
+        mta_extractor = meta_extractor.SetupPipe()
+        mta_extractor.transform(xml)
+
+        self.assertEqual(mta_extractor.transform(xml), (None, {}))
+
+
+class TitlePipeTest(unittest.TestCase):
+
+    def test_if_title_pipe_return_correct_dict(self):
+        xml_str = '''
+            <article>
+              <article-meta>
+                <title-group>
+                  <article-title xml:lang="pt">Pesquisa em saude</article-title>
+                  <trans-title-group xml:lang="es">
+                    <trans-title>Investigacion en salud</trans-title>
+                  </trans-title-group>
+                </title-group>
+              </article-meta>
+            </article>'''
+
+        xml = etree.parse(StringIO(xml_str))
+
+        expected = {
+                "title-group": {
+                    "pt": "Pesquisa em saude",
+                    "es": "Investigacion en salud"
+                }
+              }
+
+        mta_extractor = meta_extractor.TitlePipe()
+        xml, dict_data = mta_extractor.transform([xml, {}])
+
+        self.assertEqual(dict_data, expected)
+
+    def test_if_title_pipe_treats_the_absent_of_trans_title_group(self):
+        xml_str = '''
+            <article>
+              <article-meta>
+                <title-group>
+                  <article-title xml:lang="pt">Pesquisa em saude</article-title>
+                </title-group>
+              </article-meta>
+            </article>'''
+
+        xml = etree.parse(StringIO(xml_str))
+
+        expected = {
+                "title-group": {
+                    "pt": "Pesquisa em saude",
+                }
+              }
+
+        mta_extractor = meta_extractor.TitlePipe()
+        xml, dict_data = mta_extractor.transform([xml, {}])
+
+        self.assertEqual(dict_data, expected)
+
+    def test_if_title_pipe_treats_the_absent_of_article_title(self):
+        xml_str = '''
+            <article>
+              <article-meta>
+                <title-group>
+                  <trans-title-group xml:lang="es">
+                    <trans-title>Investigacion en salud</trans-title>
+                  </trans-title-group>
+                </title-group>
+              </article-meta>
+            </article>'''
+
+        xml = etree.parse(StringIO(xml_str))
+
+        expected = {
+                "title-group": {
+                    "es": "Investigacion en salud"
+                }
+              }
+
+        mta_extractor = meta_extractor.TitlePipe()
+        xml, dict_data = mta_extractor.transform([xml, {}])
+
+        self.assertEqual(dict_data, expected)
+
+
+class AbbrevJournalTitlePipeTest(unittest.TestCase):
+
+    def test_if_abbrev_journal_title_pipe_return_correct_dict(self):
+        xml_str = '''
+            <article>
+              <journal-meta>
+                <journal-title-group>
+                  <journal-title>Revista de Saúde Pública</journal-title>
+                  <abbrev-journal-title abbrev-type="publisher">Rev. Saude Publica</abbrev-journal-title>
+                </journal-title-group>
+              </journal-meta>
+            </article>'''
+
+        xml = etree.parse(StringIO(xml_str))
+
+        expected = {"abbrev-journal-title": "Rev. Saude Publica"}
+
+        mta_extractor = meta_extractor.AbbrevJournalTitlePipe()
+        xml, dict_data = mta_extractor.transform([xml, {}])
+
+        self.assertEqual(dict_data, expected)
+
+    def test_abbrev_journal_title_pipe_treats_the_absent_of_abbrev_journal_title(self):
+        xml_str = '''
+            <article>
+              <journal-meta>
+                <journal-title-group>
+                  <journal-title>Revista de Saúde Pública</journal-title>
+                </journal-title-group>
+              </journal-meta>
+            </article>'''
+
+        xml = etree.parse(StringIO(xml_str))
+
+        expected = {}
+
+        mta_extractor = meta_extractor.AbbrevJournalTitlePipe()
+        xml, dict_data = mta_extractor.transform([xml, {}])
+
+        self.assertEqual(dict_data, expected)
+
+    def test_abbrev_journal_title_pipe_treats_the_absent_of_journal_meta(self):
+        xml_str = '''
+            <article>
+                <journal-title-group>
+                  <journal-title>Revista de Saúde Pública</journal-title>
+                  <abbrev-journal-title abbrev-type="publisher">Rev. Saude Publica</abbrev-journal-title>
+                </journal-title-group>
+            </article>'''
+
+        xml = etree.parse(StringIO(xml_str))
+
+        expected = {'abbrev-journal-title': 'Rev. Saude Publica'}
+
+        mta_extractor = meta_extractor.AbbrevJournalTitlePipe()
+        xml, dict_data = mta_extractor.transform([xml, {}])
+
+        self.assertEqual(dict_data, expected)
+
+    def test_abbrev_journal_title_pipe_treats_the_absent_of_journal_title_group(self):
+        xml_str = '''
+            <article>
+              <journal-meta>
+                  <journal-title>Revista de Saúde Pública</journal-title>
+                  <abbrev-journal-title abbrev-type="publisher">Rev. Saude Publica</abbrev-journal-title>
+              </journal-meta>
+            </article>'''
+
+        xml = etree.parse(StringIO(xml_str))
+
+        expected = {}
+
+        mta_extractor = meta_extractor.AbbrevJournalTitlePipe()
+        xml, dict_data = mta_extractor.transform([xml, {}])
+
+        self.assertEqual(dict_data, expected)
+
+
+class AbstractPipePipeTest(unittest.TestCase):
+
+    def test_if_abstract_pipe_return_correct_dict(self):
+        xml_str = '''
+            <article>
+              <article-meta>
+                <abstract xml:lang="pt">
+                    Discute-se a utilizacao do conceito de ...
+                </abstract>
+                <trans-abstract xml:lang="es">
+                    Se discute la utilizacion del concepto de ...
+                </trans-abstract>
+              </article-meta>
+            </article>'''
+
+        xml = etree.parse(StringIO(xml_str))
+
+        expected = {
+                    "abstract": {
+                        "pt": "Discute-se a utilizacao do conceito de ...",
+                        "es": "Se discute la utilizacion del concepto de ..."
+                    }
+                }
+        mta_extractor = meta_extractor.AbstractPipe()
+        xml, dict_data = mta_extractor.transform([xml, {}])
+
+        self.assertEqual(dict_data, expected)
+
+    def test_abbrev_journal_title_pipe_treats_the_absent_of_trans_abstract(self):
+        xml_str = '''
+            <article>
+              <article-meta>
+                <abstract xml:lang="pt">
+                    Discute-se a utilizacao do conceito de ...
+                </abstract>
+              </article-meta>
+            </article>'''
+
+        xml = etree.parse(StringIO(xml_str))
+
+        expected = {
+            "abstract": {
+                "pt": "Discute-se a utilizacao do conceito de ...",
+            }
+        }
+
+        mta_extractor = meta_extractor.AbstractPipe()
+        xml, dict_data = mta_extractor.transform([xml, {}])
+
+        self.assertEqual(dict_data, expected)
+
+    def test_abbrev_journal_title_pipe_treats_the_absent_of_abstract(self):
+        xml_str = '''
+            <article>
+              <article-meta>
+                <trans-abstract xml:lang="es">
+                    Se discute la utilizacion del concepto de ...
+                </trans-abstract>
+              </article-meta>
+            </article>'''
+
+        xml = etree.parse(StringIO(xml_str))
+
+        expected = {
+            "abstract": {
+                "es": "Se discute la utilizacion del concepto de ...",
+            }
+        }
+
+        mta_extractor = meta_extractor.AbstractPipe()
+        xml, dict_data = mta_extractor.transform([xml, {}])
+
+        self.assertEqual(dict_data, expected)
+
+
+class JournalIDPipeTest(unittest.TestCase):
+
+    def test_if_journal_id_pipe_return_correct_dict(self):
+        xml_str = '''
+                <article>
+                  <journal-meta>
+                    <journal-id journal-id-type="nlm-ta">Rev Saude Publica</journal-id>
+                  </journal-meta>
+                </article>'''
+
+        xml = etree.parse(StringIO(xml_str))
+
+        expected = {
+                    "journal-id": "Rev Saude Publica",
+                   }
+
+        mta_extractor = meta_extractor.JournalIDPipe()
+        xml, dict_data = mta_extractor.transform([xml, {}])
+
+        self.assertEqual(dict_data, expected)
+
+    def test_abbrev_journal_title_pipe_treats_the_absent_of_journal_id(self):
+        xml_str = '''
+                <article>
+                  <journal-meta>
+                  </journal-meta>
+                </article>'''
+
+        xml = etree.parse(StringIO(xml_str))
+
+        expected = {}
+
+        mta_extractor = meta_extractor.JournalIDPipe()
+        xml, dict_data = mta_extractor.transform([xml, {}])
+
+        self.assertEqual(dict_data, expected)
+
+
+class LpagePipeTest(unittest.TestCase):
+
+    def test_if_lpage_pipe_return_correct_dict(self):
+        xml_str = '''
+                <article>
+                  <article-meta>
+                    <lpage>655</lpage>
+                  </article-meta>
+                </article>'''
+
+        xml = etree.parse(StringIO(xml_str))
+
+        expected = {
+                    "lpage": "655",
+                   }
+
+        mta_extractor = meta_extractor.LpagePipe()
+        xml, dict_data = mta_extractor.transform([xml, {}])
+
+        self.assertEqual(dict_data, expected)
+
+    def test_abbrev_journal_title_pipe_treats_the_absent_of_lpage(self):
+        xml_str = '''
+                <article>
+                  <article-meta>
+                  </article-meta>
+                </article>'''
+
+        xml = etree.parse(StringIO(xml_str))
+
+        expected = {}
+
+        mta_extractor = meta_extractor.LpagePipe()
+        xml, dict_data = mta_extractor.transform([xml, {}])
+
+        self.assertEqual(dict_data, expected)
+
+
+class FpagePipeTest(unittest.TestCase):
+
+    def test_if_Fpage_pipe_return_correct_dict(self):
+        xml_str = '''
+                <article>
+                  <article-meta>
+                    <fpage>647</fpage>
+                  </article-meta>
+                </article>'''
+
+        xml = etree.parse(StringIO(xml_str))
+
+        expected = {
+                    "fpage": "647",
+                   }
+
+        mta_extractor = meta_extractor.FpagePipe()
+        xml, dict_data = mta_extractor.transform([xml, {}])
+
+        self.assertEqual(dict_data, expected)
+
+    def test_abbrev_journal_title_pipe_treats_the_absent_of_fpage(self):
+        xml_str = '''
+                <article>
+                  <article-meta>
+                  </article-meta>
+                </article>'''
+
+        xml = etree.parse(StringIO(xml_str))
+
+        expected = {}
+
+        mta_extractor = meta_extractor.FpagePipe()
+        xml, dict_data = mta_extractor.transform([xml, {}])
+
+        self.assertEqual(dict_data, expected)
+
+
+class JournalTitlePipeTest(unittest.TestCase):
+
+    def test_if_jouranl_title_pipe_return_correct_dict(self):
+        xml_str = '''
+                <article>
+                  <journal-meta>
+                    <journal-title-group>
+                      <journal-title>Revista de Saude Publica</journal-title>
+                    </journal-title-group>
+                  </journal-meta>
+                </article>'''
+
+        xml = etree.parse(StringIO(xml_str))
+
+        expected = {
+                    "journal-title": "Revista de Saude Publica",
+                   }
+
+        mta_extractor = meta_extractor.JournalTitlePipe()
+        xml, dict_data = mta_extractor.transform([xml, {}])
+
+        self.assertEqual(dict_data, expected)
+
+    def test_abbrev_journal_title_pipe_treats_the_absent_of_fpage(self):
+        xml_str ='''
+                <article>
+                  <journal-meta>
+                    <journal-title-group>
+                    </journal-title-group>
+                  </journal-meta>
+                </article>'''
+
+        xml = etree.parse(StringIO(xml_str))
+
+        expected = {}
+
+        mta_extractor = meta_extractor.JournalTitlePipe()
+        xml, dict_data = mta_extractor.transform([xml, {}])
+
+        self.assertEqual(dict_data, expected)
+
+
+class AuthorPipeTest(unittest.TestCase):
+
+    def test_if_author_pipe_return_correct_dict(self):
+        xml_str = '''
+              <article>
+                <journal-meta>
+                  <contrib-group>
+                    <contrib contrib-type="author">
+                      <name>
+                        <surname>Soysal</surname>
+                        <given-names>Ahmet</given-names>
+                      </name>
+                      <xref ref-type="aff" rid="aff1">
+                        <sup>I</sup>
+                      </xref>
+                    </contrib>
+                    <contrib contrib-type="author">
+                      <name>
+                        <surname>Simsek</surname>
+                        <given-names>Hatice</given-names>
+                      </name>
+                      <xref ref-type="aff" rid="aff1">
+                        <sup>I</sup>
+                      </xref>
+                    </contrib>
+                  </contrib-group>
+                </journal-meta>
+              </article>'''
+
+        xml = etree.parse(StringIO(xml_str))
+
+        expected = {
+                "contrib-group": {
+                  "authors": [
+                    {
+                      "given-names": "Ahmet",
+                      "surname": "Soysal",
+                      "affiliations": [
+                        "aff1"
+                      ]
+                    },
+                    {
+                      "given-names": "Hatice",
+                      "surname": "Simsek",
+                      "affiliations": [
+                        "aff1"
+                      ]
+                    }]
+                  }
+                }
+
+        mta_extractor = meta_extractor.AuthorPipe()
+        xml, dict_data = mta_extractor.transform([xml, {}])
+
+        self.assertEqual(dict_data, expected)
+
+    def test_if_author_title_pipe_treats_the_absent_of_contrib(self):
+        xml_str = '''
+              <article>
+                <journal-meta>
+                  <contrib-group>
+                      <name>
+                        <surname>Soysal</surname>
+                        <given-names>Ahmet</given-names>
+                      </name>
+                      <xref ref-type="aff" rid="aff1">
+                        <sup>I</sup>
+                      </xref>
+                    <contrib contrib-type="author">
+                      <name>
+                        <surname>Simsek</surname>
+                        <given-names>Hatice</given-names>
+                      </name>
+                      <xref ref-type="aff" rid="aff1">
+                        <sup>I</sup>
+                      </xref>
+                    </contrib>
+                  </contrib-group>
+                </journal-meta>
+              </article>'''
+
+        xml = etree.parse(StringIO(xml_str))
+
+        expected = {
+                "contrib-group": {
+                  "authors": [
+                    {
+                      "given-names": "Hatice",
+                      "surname": "Simsek",
+                      "affiliations": [
+                        "aff1"
+                      ]
+                    }]
+                  }
+                }
+
+        mta_extractor = meta_extractor.AuthorPipe()
+        xml, dict_data = mta_extractor.transform([xml, {}])
+
+        self.assertEqual(dict_data, expected)
+
+    def test_if_author_title_pipe_treats_the_absent_of_any_ref(self):
+        xml_str = '''
+            <article>
+                <journal-meta>
+                  <contrib-group>
+                    <contrib contrib-type="author">
+                      <name>
+                        <surname>Soysal</surname>
+                        <given-names>Ahmet</given-names>
+                      </name>
+                    </contrib>
+                    <contrib contrib-type="author">
+                      <name>
+                        <surname>Simsek</surname>
+                        <given-names>Hatice</given-names>
+                      </name>
+                      <xref ref-type="aff" rid="aff1">
+                        <sup>I</sup>
+                      </xref>
+                    </contrib>
+                  </contrib-group>
+                </journal-meta>
+            </article>'''
+
+        xml = etree.parse(StringIO(xml_str))
+
+        expected = {
+                "contrib-group": {
+                  "authors": [
+                    {
+                      "given-names": "Ahmet",
+                      "surname": "Soysal",
+                      "affiliations": []
+                    },
+                    {
+                      "given-names": "Hatice",
+                      "surname": "Simsek",
+                      "affiliations": [
+                        "aff1"
+                      ]
+                    }]
+                  }
+                }
+
+        mta_extractor = meta_extractor.AuthorPipe()
+        xml, dict_data = mta_extractor.transform([xml, {}])
+
+        self.assertEqual(dict_data, expected)
+
+class AffiliationPipeTest(unittest.TestCase):
+
+    def test_if_affiliation_pipe_return_correct_dict(self):
+        xml_str = '''
+            <article>
+                <article-meta>
+                <aff id="aff1">
+                    <institution content-type="orgname">Santa Casa de Sao Paulo</institution>
+                    <addr-line>
+                    <named-content content-type="city">Sao Paulo</named-content>
+                    <named-content content-type="state">SP</named-content>
+                    </addr-line>
+                    <country>Brasil</country>
+                </aff>
+                <aff id="aff2">
+                    <institution content-type="orgname">Universidade de Sao Paulo</institution>
+                    <addr-line>
+                    <named-content content-type="city">Sao Paulo</named-content>
+                    <named-content content-type="state">SP</named-content>
+                    </addr-line>
+                    <country>Brasil</country>
+                </aff>
+                </article-meta>
+            </article>'''
+
+        xml = etree.parse(StringIO(xml_str))
+
+        expected = {
+              "affiliations": [
+                {
+                  "ref": "aff1",
+                  "institution": "Santa Casa de Sao Paulo",
+                  "country": "Brasil"
+                },
+                {
+                  "ref": "aff2",
+                  "institution": "Universidade de Sao Paulo",
+                  "country": "Brasil"
+                },
+              ],
+            }
+
+        mta_extractor = meta_extractor.AffiliationPipe()
+        xml, dict_data = mta_extractor.transform([xml, {}])
+
+        self.assertEqual(dict_data, expected)
+
+    # def test_if_author_title_pipe_treats_the_absent_of_contrib(self):
+    #     xml_str = '''
+    #           <article>
+    #             <journal-meta>
+    #               <contrib-group>
+    #                   <name>
+    #                     <surname>Soysal</surname>
+    #                     <given-names>Ahmet</given-names>
+    #                   </name>
+    #                   <xref ref-type="aff" rid="aff1">
+    #                     <sup>I</sup>
+    #                   </xref>
+    #                 <contrib contrib-type="author">
+    #                   <name>
+    #                     <surname>Simsek</surname>
+    #                     <given-names>Hatice</given-names>
+    #                   </name>
+    #                   <xref ref-type="aff" rid="aff1">
+    #                     <sup>I</sup>
+    #                   </xref>
+    #                 </contrib>
+    #               </contrib-group>
+    #             </journal-meta>
+    #           </article>'''
+
+    #     xml = etree.parse(StringIO(xml_str))
+
+    #     expected = {
+    #             "contrib-group": {
+    #               "authors": [
+    #                 {
+    #                   "given-names": "Hatice",
+    #                   "surname": "Simsek",
+    #                   "affiliations": [
+    #                     "aff1"
+    #                   ]
+    #                 }]
+    #               }
+    #             }
+
+    #     mta_extractor = meta_extractor.AuthorPipe()
+    #     xml, dict_data = mta_extractor.transform([xml, {}])
+
+    #     self.assertEqual(dict_data, expected)
+
+    # def test_if_author_title_pipe_treats_the_absent_of_any_ref(self):
+    #     xml_str = '''
+    #         <article>
+    #             <journal-meta>
+    #               <contrib-group>
+    #                 <contrib contrib-type="author">
+    #                   <name>
+    #                     <surname>Soysal</surname>
+    #                     <given-names>Ahmet</given-names>
+    #                   </name>
+    #                 </contrib>
+    #                 <contrib contrib-type="author">
+    #                   <name>
+    #                     <surname>Simsek</surname>
+    #                     <given-names>Hatice</given-names>
+    #                   </name>
+    #                   <xref ref-type="aff" rid="aff1">
+    #                     <sup>I</sup>
+    #                   </xref>
+    #                 </contrib>
+    #               </contrib-group>
+    #             </journal-meta>
+    #         </article>'''
+
+    #     xml = etree.parse(StringIO(xml_str))
+
+    #     expected = {
+    #             "contrib-group": {
+    #               "authors": [
+    #                 {
+    #                   "given-names": "Ahmet",
+    #                   "surname": "Soysal",
+    #                   "affiliations": []
+    #                 },
+    #                 {
+    #                   "given-names": "Hatice",
+    #                   "surname": "Simsek",
+    #                   "affiliations": [
+    #                     "aff1"
+    #                   ]
+    #                 }]
+    #               }
+    #             }
+
+    #     mta_extractor = meta_extractor.AuthorPipe()
+    #     xml, dict_data = mta_extractor.transform([xml, {}])
+
+    #     self.assertEqual(dict_data, expected)
+
+
+
+
+
+
+

--- a/balaio/tests/utils.py
+++ b/balaio/tests/utils.py
@@ -18,7 +18,7 @@ def db_bootstrap():
 
     :returns: an instance of engine.
     """
-    engine = create_engine('postgresql+psycopg2://postgres:@localhost/%s' % DB_NAME, echo=False)
+    engine = create_engine('postgresql+psycopg2://postgres:123@localhost:5432/%s' % DB_NAME, echo=False)
     try:
         models.Base.metadata.drop_all(engine)
     except OperationalError as e:


### PR DESCRIPTION
@scieloorg

Foi criado um PIPELINE para construir o JSON que será depositado no Manager SciELO após a fase de validação. Necessário no futuro discutirmos a cola entre os módulos `checkout` e `meta_extractor`.
