### PR TITLE
Adição do campo models.ArticlePkg.aid para armazenar o article-id

### DIFF
--- a/balaio/base28.py
+++ b/balaio/base28.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python
+# coding: utf-8
+
+import string
+from random import randrange
+
+BASE36 = string.digits+string.ascii_lowercase
+# sem vogais, para nao formar palavras em portugues
+# sem 1l0, para evitar confusões na leitura
+BASE28 = ''.join(d for d in BASE36 if d not in '1l0aeiou')
+
+def reprbase(n, digitos=BASE28):
+    ''' devolve a representação do valor `n` usando `digitos` '''
+    base = len(digitos)
+    s = []
+    while n:
+        n, d = divmod(n, base)
+        s.insert(0, digitos[d])
+    if s:
+        return ''.join(s)
+    else:
+        return digitos[0]
+
+def calcbase(s, digitos=BASE28):
+    ''' devolve o valor numérico de `s` na base representada pelos dígitos '''
+    return sum(digitos.index(dig)*len(digitos)**pot
+               for pot, dig in enumerate(reversed(s)))
+
+def genbase(tamanho, digitos=BASE28):
+    return reprbase(randrange(len(digitos)**tamanho), digitos).rjust(tamanho,digitos[0])
+
+if __name__=='__main__':
+    print 'Amostra de alguns números em base 28'
+
+    l = range(11)
+    l.extend([calcbase(x) for x in ('3zz', '422','4zz','522','zzz','3222')])
+    l.extend([27,28,29,28**2-1,28**2,1001,1100,1200,2000])
+
+    for n in sorted(l):
+        v = reprbase(n)
+        assert n == calcbase(v)
+        print '%8d\t%8s' % (n, reprbase(n))
+

--- a/balaio/models.py
+++ b/balaio/models.py
@@ -25,6 +25,8 @@ from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.ext.hybrid import hybrid_property
 from zope.sqlalchemy import ZopeTransactionExtension
 
+from base28 import genbase
+
 
 logger = logging.getLogger(__name__)
 
@@ -111,6 +113,7 @@ class ArticlePkg(Base):
     __tablename__ = 'articlepkg'
 
     id = Column(Integer, primary_key=True)
+    aid = Column(String, nullable=False, index=True, unique=True)
     article_title = Column(String, nullable=False)
     journal_pissn = Column(String, nullable=True)
     journal_eissn = Column(String, nullable=True)
@@ -121,8 +124,19 @@ class ArticlePkg(Base):
     issue_suppl_volume = Column(String, nullable=True)
     issue_suppl_number = Column(String, nullable=True)
 
+    def __init__(self, *args, **kwargs):
+        super(ArticlePkg, self).__init__(*args, **kwargs)
+        self.aid = self.get_aid()
+
+    def get_aid(self):
+        """
+        Produce a fresh `aid` only for instances not yet persisted.
+        """
+        return self.aid if (self.id and self.aid) else genbase(10)
+
     def to_dict(self):
         return dict(id=self.id,
+                    aid=self.aid,
                     article_title=self.article_title,
                     journal_pissn=self.journal_pissn,
                     journal_eissn=self.journal_eissn,

--- a/balaio/tests/test_httpd.py
+++ b/balaio/tests/test_httpd.py
@@ -685,6 +685,7 @@ class PackageFunctionalAPITest(unittest.TestCase):
 
     def test_GET_to_one_package(self):
         articlepkg_id = self._loaded_fixtures[0].id
+        articlepkg_aid = self._loaded_fixtures[0].aid
 
         res = self.testapp.get('/api/v1/packages/%s/' % articlepkg_id)
 
@@ -700,7 +701,8 @@ class PackageFunctionalAPITest(unittest.TestCase):
                        "issue_volume": "67",
                        "resource_uri": "/api/v1/packages/%s/",
                        "id": %s,
-                       "issue_number": "8"}''' % (articlepkg_id, articlepkg_id)
+                       "aid": "%s",
+                       "issue_number": "8"}''' % (articlepkg_id, articlepkg_id, articlepkg_aid)
 
         self.assertEqual(json.loads(res.body), json.loads(expected))
 
@@ -708,6 +710,10 @@ class PackageFunctionalAPITest(unittest.TestCase):
         articlepkg0_id = self._loaded_fixtures[0].id
         articlepkg1_id = self._loaded_fixtures[1].id
         articlepkg2_id = self._loaded_fixtures[2].id
+
+        articlepkg0_aid = self._loaded_fixtures[0].aid
+        articlepkg1_aid = self._loaded_fixtures[1].aid
+        articlepkg2_aid = self._loaded_fixtures[2].aid
 
         res = self.testapp.get('/api/v1/packages/')
 
@@ -725,6 +731,7 @@ class PackageFunctionalAPITest(unittest.TestCase):
                             "issue_volume": "67",
                             "resource_uri": "/api/v1/packages/%s/",
                             "id": %s,
+                            "aid": "%s",
                             "issue_number": "8"},
                            {"article_title": "Construction of a recombinant adenovirus...",
                             "tickets": [],
@@ -738,6 +745,7 @@ class PackageFunctionalAPITest(unittest.TestCase):
                             "issue_volume": "67",
                             "resource_uri": "/api/v1/packages/%s/",
                             "id": %s,
+                            "aid": "%s",
                             "issue_number": "8"},
                            {"article_title": "Construction of a recombinant adenovirus...",
                             "tickets": [],
@@ -751,10 +759,11 @@ class PackageFunctionalAPITest(unittest.TestCase):
                             "issue_volume": "67",
                             "resource_uri": "/api/v1/packages/%s/",
                             "id": %s,
+                            "aid": "%s",
                             "issue_number": "8"}
-                    ]}''' % (articlepkg0_id, articlepkg0_id,
-                             articlepkg1_id, articlepkg1_id,
-                             articlepkg2_id, articlepkg2_id)
+                    ]}''' % (articlepkg0_id, articlepkg0_id, articlepkg0_aid,
+                             articlepkg1_id, articlepkg1_id, articlepkg1_aid,
+                             articlepkg2_id, articlepkg2_id, articlepkg2_aid)
 
         self.assertEqual(json.loads(res.body), json.loads(expected))
 
@@ -762,6 +771,10 @@ class PackageFunctionalAPITest(unittest.TestCase):
         articlepkg0_id = self._loaded_fixtures[0].id
         articlepkg1_id = self._loaded_fixtures[1].id
         articlepkg2_id = self._loaded_fixtures[2].id
+
+        articlepkg0_aid = self._loaded_fixtures[0].aid
+        articlepkg1_aid = self._loaded_fixtures[1].aid
+        articlepkg2_aid = self._loaded_fixtures[2].aid
 
         res = self.testapp.get('/api/v1/packages/?limit=82')
 
@@ -779,6 +792,7 @@ class PackageFunctionalAPITest(unittest.TestCase):
                             "issue_volume": "67",
                             "resource_uri": "/api/v1/packages/%s/",
                             "id": %s,
+                            "aid": "%s",
                             "issue_number": "8"},
                            {"article_title": "Construction of a recombinant adenovirus...",
                             "tickets": [],
@@ -792,6 +806,7 @@ class PackageFunctionalAPITest(unittest.TestCase):
                             "issue_volume": "67",
                             "resource_uri": "/api/v1/packages/%s/",
                             "id": %s,
+                            "aid": "%s",
                             "issue_number": "8"},
                            {"article_title": "Construction of a recombinant adenovirus...",
                             "tickets": [],
@@ -805,16 +820,20 @@ class PackageFunctionalAPITest(unittest.TestCase):
                             "issue_volume": "67",
                             "resource_uri": "/api/v1/packages/%s/",
                             "id": %s,
+                            "aid": "%s",
                             "issue_number": "8"}
-                    ]}''' % (articlepkg0_id, articlepkg0_id,
-                             articlepkg1_id, articlepkg1_id,
-                             articlepkg2_id, articlepkg2_id)
+                    ]}''' % (articlepkg0_id, articlepkg0_id, articlepkg0_aid,
+                             articlepkg1_id, articlepkg1_id, articlepkg1_aid,
+                             articlepkg2_id, articlepkg2_id, articlepkg2_aid)
 
         self.assertEqual(json.loads(res.body), json.loads(expected))
 
     def test_GET_to_packages_with_param_offset(self):
         articlepkg1_id = self._loaded_fixtures[1].id
         articlepkg2_id = self._loaded_fixtures[2].id
+
+        articlepkg1_aid = self._loaded_fixtures[1].aid
+        articlepkg2_aid = self._loaded_fixtures[2].aid
 
         res = self.testapp.get('/api/v1/packages/?offset=1')
 
@@ -832,6 +851,7 @@ class PackageFunctionalAPITest(unittest.TestCase):
                             "issue_volume": "67",
                             "resource_uri": "/api/v1/packages/%s/",
                             "id": %s,
+                            "aid": "%s",
                             "issue_number": "8"},
                            {"article_title": "Construction of a recombinant adenovirus...",
                             "tickets": [],
@@ -845,9 +865,10 @@ class PackageFunctionalAPITest(unittest.TestCase):
                             "issue_volume": "67",
                             "resource_uri": "/api/v1/packages/%s/",
                             "id": %s,
+                            "aid": "%s",
                             "issue_number": "8"}
-                    ]}''' % (articlepkg1_id, articlepkg1_id,
-                             articlepkg2_id, articlepkg2_id)
+                    ]}''' % (articlepkg1_id, articlepkg1_id, articlepkg1_aid,
+                             articlepkg2_id, articlepkg2_id, articlepkg2_aid)
 
         self.assertEqual(json.loads(res.body), json.loads(expected))
 
@@ -859,6 +880,9 @@ class PackageFunctionalAPITest(unittest.TestCase):
     def test_GET_to_packages_with_param_low_limit(self):
         articlepkg0_id = self._loaded_fixtures[0].id
         articlepkg1_id = self._loaded_fixtures[1].id
+
+        articlepkg0_aid = self._loaded_fixtures[0].aid
+        articlepkg1_aid = self._loaded_fixtures[1].aid
 
         res = self.testapp.get('/api/v1/packages/?limit=2')
 
@@ -876,6 +900,7 @@ class PackageFunctionalAPITest(unittest.TestCase):
                             "issue_volume": "67",
                             "resource_uri": "/api/v1/packages/%s/",
                             "id": %s,
+                            "aid": "%s",
                             "issue_number": "8"},
                            {"article_title": "Construction of a recombinant adenovirus...",
                             "tickets": [],
@@ -889,15 +914,19 @@ class PackageFunctionalAPITest(unittest.TestCase):
                             "issue_volume": "67",
                             "resource_uri": "/api/v1/packages/%s/",
                             "id": %s,
+                            "aid": "%s",
                             "issue_number": "8"}
-                    ]}''' % (articlepkg0_id, articlepkg0_id,
-                             articlepkg1_id, articlepkg1_id)
+                    ]}''' % (articlepkg0_id, articlepkg0_id, articlepkg0_aid,
+                             articlepkg1_id, articlepkg1_id, articlepkg1_aid)
 
         self.assertEqual(json.loads(res.body), json.loads(expected))
 
     def test_GET_to_packages_with_param_low_offset_and_limit(self):
         articlepkg1_id = self._loaded_fixtures[1].id
         articlepkg2_id = self._loaded_fixtures[2].id
+
+        articlepkg1_aid = self._loaded_fixtures[1].aid
+        articlepkg2_aid = self._loaded_fixtures[2].aid
 
         res = self.testapp.get('/api/v1/packages/?limit=2&offset=1')
 
@@ -915,6 +944,7 @@ class PackageFunctionalAPITest(unittest.TestCase):
                             "issue_volume": "67",
                             "resource_uri": "/api/v1/packages/%s/",
                             "id": %s,
+                            "aid": "%s",
                             "issue_number": "8"},
                            {"article_title": "Construction of a recombinant adenovirus...",
                             "tickets": [],
@@ -928,14 +958,16 @@ class PackageFunctionalAPITest(unittest.TestCase):
                             "issue_volume": "67",
                             "resource_uri": "/api/v1/packages/%s/",
                             "id": %s,
+                            "aid": "%s",
                             "issue_number": "8"}
-                    ]}''' % (articlepkg1_id, articlepkg1_id,
-                             articlepkg2_id, articlepkg2_id)
+                    ]}''' % (articlepkg1_id, articlepkg1_id, articlepkg1_aid,
+                             articlepkg2_id, articlepkg2_id, articlepkg2_aid)
 
         self.assertEqual(json.loads(res.body), json.loads(expected))
 
     def test_GET_to_packages_with_param_low_limit_and_offset(self):
         articlepkg2_id = self._loaded_fixtures[2].id
+        articlepkg2_aid = self._loaded_fixtures[2].aid
 
         res = self.testapp.get('/api/v1/packages/?limit=1&offset=2')
 
@@ -953,8 +985,9 @@ class PackageFunctionalAPITest(unittest.TestCase):
                             "issue_volume": "67",
                             "resource_uri": "/api/v1/packages/%s/",
                             "id": %s,
+                            "aid": "%s",
                             "issue_number": "8"}
-                    ]}''' % (articlepkg2_id, articlepkg2_id)
+                    ]}''' % (articlepkg2_id, articlepkg2_id, articlepkg2_aid)
 
         self.assertEqual(json.loads(res.body), json.loads(expected))
 

--- a/balaio/validator.py
+++ b/balaio/validator.py
@@ -122,7 +122,12 @@ class TearDownPipe(vpipes.Pipe):
         try:
             attempt, pkg_analyzer, __, db_session = item
         except TypeError:
+            # when a message is broken since the beginning in ways
+            # it couldn't be processed by the SetupPipe, this
+            # unpacking will fail as only an attempt instance is
+            # referenced by `item`.
             attempt = item
+            db_session = models.Session()
 
         logger.debug('%s started processing %s' % (self.__class__.__name__, item))
 

--- a/docs/dev/packages-api.rst
+++ b/docs/dev/packages-api.rst
@@ -58,6 +58,9 @@ Optional Parameters:
 
      *Integer* of the **id**  to be used as a filter param.
 
+  **aid**
+
+     *String* of the **article-id**  to be used as a filter param.
 
 Response::
 
@@ -86,6 +89,7 @@ Response::
             ],
             issue_suppl_volume: "1",
             issue_volume: "1",
+            aid: "yp4529bp8g",
             resource_uri: "/api/v1/packages/3/",
             id: 3,
             issue_number: "1"
@@ -106,6 +110,7 @@ Response::
             ],
             issue_suppl_volume: "7",
             issue_volume: "11",
+            aid: "jp4599bq8g",
             resource_uri: "/api/v1/packages/4/",
             id: 4,
             issue_number: "3"
@@ -150,6 +155,7 @@ Response::
       ],
       issue_suppl_volume: "1",
       issue_volume: "1",
+      aid: "yp4529bp8g",
       resource_uri: "/api/v1/packages/3/",
       id: 3,
       issue_number: "1"


### PR DESCRIPTION
O módulo **base28.py**, que já é parte integrante de outros projetos como nurl e scielobooks, foi adicionado para a conversão de base 10 para base 28.
