### PR TITLE
Melhorando o código do checkout, método upload_static_files

### DIFF
--- a/balaio/package.py
+++ b/balaio/package.py
@@ -53,6 +53,7 @@ class PackageAnalyzer(xray.SPSPackage):
         """
         Returns a subset of the zip package according to a list of members/files.
         """
+
         dmembers = {member:self.get_fp(member).read() for member in members}
 
         return utils.zip_files(dmembers)


### PR DESCRIPTION
Alterado o método upload_static_files para utilizar o método `subzip` e removido o método get_static_files do módulo checkout.
