### PR TITLE
Removido método hibrido da entidade attempt

### DIFF
--- a/balaio/checkout.py
+++ b/balaio/checkout.py
@@ -146,7 +146,7 @@ def main(config):
 
         attempts_checkout = session.query(models.Attempt).filter_by(
                                           proceed_to_checkout=True,
-                                          pending_checkout=True).all()
+                                          checkout_started_at=None).all()
 
         #Process only if exists itens
         if attempts_checkout:

--- a/balaio/models.py
+++ b/balaio/models.py
@@ -130,16 +130,6 @@ class Attempt(Base):
     def __repr__(self):
         return "<Attempt('%s, %s')>" % (self.id, self.package_checksum)
 
-
-    @hybrid_property
-    def pending_checkout(self):
-        """
-        Verify if the item is pending to checkout based on ``proceed_to_checkout``
-        and ``checkout_started_at``.
-        """
-        return self.proceed_to_checkout and not self.checkout_started_at
-
-
     @classmethod
     def get_from_package(cls, package):
         """

--- a/balaio/tests/test_models.py
+++ b/balaio/tests/test_models.py
@@ -167,33 +167,6 @@ class AttemptTests(mocker.MockerTestCase):
         attempt = Attempt.get_from_package(pkg_analyzer)
         self.assertFalse(attempt.is_valid)
 
-    def test_pending_checkout_must_ret_False_proceed_check_true_check_started_at_false(self):
-        attempt = Attempt()
-        attempt.proceed_to_checkout = True
-        attempt.checkout_started_at = datetime.now()
-
-        self.assertFalse(attempt.pending_checkout)
-
-    def test_pending_checkout_must_ret_False_proceed_check_false_check_started_at_true(self):
-        attempt = Attempt()
-        attempt.proceed_to_checkout = False
-        attempt.checkout_started_at = datetime.now()
-
-        self.assertFalse(attempt.pending_checkout)
-
-    def test_pending_checkout_must_ret_False_proceed_check_false_check_started_at_false(self):
-        attempt = Attempt()
-        attempt.proceed_to_checkout = False
-        attempt.checkout_started_at = None
-
-        self.assertFalse(attempt.pending_checkout)
-
-    def test_pending_checkout_must_ret_True_proceed_check_true_check_started_at_false(self):
-        attempt = Attempt()
-        attempt.proceed_to_checkout = True
-        attempt.checkout_started_at = None
-
-        self.assertTrue(attempt.pending_checkout)
 
 
 class ArticlePkgTests(mocker.MockerTestCase):


### PR DESCRIPTION
Durante os testes de integração do módulo de checkout e os outros módulos do balaio, foi identificado que não estávamos retornando da base de dados os objetos em condições de checkout.

Existe um erro no retorno no método híbrido do SQLAlchemy pending_checkout, dessa forma realizamos uma interação com a equipe para continuarmos utilizando esse recurso, porém sem sucesso. 

Realizei a remoção desse método até que encontremos a forma ideal para utiliza-ló.

Ref: #238 
