### PR TITLE
XML-RPC para atualizar o proceed_to_checkout do Attempt

### DIFF
--- a/balaio/httpd.py
+++ b/balaio/httpd.py
@@ -6,8 +6,8 @@ from pyramid.httpexceptions import HTTPNotFound, HTTPAccepted, HTTPCreated, HTTP
 from pyramid.view import notfound_view_config, view_config
 from pyramid.events import NewRequest
 from pyramid.settings import asbool
-from pyramid_xmlrpc import parse_xmlrpc_request
-from pyramid_xmlrpc import xmlrpc_response
+from pyramid_xmlrpc import parse_xmlrpc_request, xmlrpc_response, xmlrpc_view
+
 
 from sqlalchemy import func
 from sqlalchemy.orm.exc import NoResultFound
@@ -126,6 +126,16 @@ def proceed_to_checkout(request):
 
     return xmlrpc_response(_return)
 
+
+@view_config(route_name='rpc_status')
+@xmlrpc_view
+def rpc_status(context):
+    """
+    XML-RPC method to test service
+    """
+    return True
+
+
 @view_config(route_name='status', request_method='GET', renderer='json')
 def health_status(request):
     """
@@ -228,6 +238,8 @@ def main(config, engine):
     config_pyrmd.add_route('list_package', '/api/v1/packages/')
     config_pyrmd.add_route('list_attempts', '/api/v1/attempts/')
 
+    # XML RPC status
+    config_pyrmd.add_route('rpc_status', '/api/v1/_rpc/status/')
     # XML RPC to mark ``proceed_to_checkout=True``
     config_pyrmd.add_route('proceed_to_checkout', '/api/v1/_rpc/proceed_to_checkout/')
 

--- a/balaio/httpd.py
+++ b/balaio/httpd.py
@@ -228,6 +228,9 @@ def main(config, engine):
     config_pyrmd.add_route('list_package', '/api/v1/packages/')
     config_pyrmd.add_route('list_attempts', '/api/v1/attempts/')
 
+    # XML RPC to mark ``proceed_to_checkout=True``
+    config_pyrmd.add_route('proceed_to_checkout', '/api/v1/_rpc/proceed_to_checkout/')
+
     # files
     config_pyrmd.add_route('list_attempt_members', '/api/v1/files/{attempt_id}/')
     config_pyrmd.add_route('get_attempt_member', '/api/v1/files/{attempt_id}/{target}/')

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,7 @@ enum34
 -e git+git://github.com/scieloorg/scieloapi.py.git#egg=scieloapi
 -e git+git://github.com/scieloorg/packtools.git#egg=packtools
 pyramid
+pyramid_xmlrpc
 WebTest
 transaction
 zope.sqlalchemy


### PR DESCRIPTION
Pessoal, 

foi criado um method no httpd para marcar o attempt como elegível para checkout, porém, acredito que tenha algo errado com os testes do httpd que não consegui descobrir. O sintoma é muito estranho: "ao adicionar qualquer teste que realize operação de escrita no modelo attempt muda a quantidade de itens no momento dos testes do ArticlePkg, ou seja um teste que esta esperando 3 itens passa a ter 6 itens e assim por diante...", de qualquer maneira realizei testes isolados e da certo.

Os testes....

``` python
    def test_proceed_to_checkout_xmlrpc_method(self):
        import xmlrpclib
        attempt_id = self._loaded_fixtures[0].id

        packet = xmlrpclib.dumps((attempt_id,), methodname='proceed_to_checkout')

        request = testing.DummyRequest()
        request.db = models.ScopedSession
        request.body = packet
        request.content_length = len(packet)

        response = httpd.proceed_to_checkout(request)

        self.assertEqual(response.content_type, 'text/xml')
        self.assertEqual(response.body, xmlrpclib.dumps((True,),
                                                        methodresponse=True))
        self.assertEqual(response.content_length, len(response.body))
        self.assertEqual(response.status, '200 OK')

    def test_proceed_to_checkout_xmlrpc_method_inexistent_id(self):
        import xmlrpclib
        attempt_id = 9999

        packet = xmlrpclib.dumps((attempt_id,), methodname='proceed_to_checkout')

        request = testing.DummyRequest()
        request.db = models.ScopedSession
        request.body = packet
        request.content_length = len(packet)

        response = httpd.proceed_to_checkout(request)

        self.assertEqual(response.content_type, 'text/xml')
        self.assertEqual(response.body, xmlrpclib.dumps((False,),
                                                        methodresponse=True))
        self.assertEqual(response.content_length, len(response.body))
        self.assertEqual(response.status, '200 OK')

    def test_proceed_to_checkout_xmlrpc_method_without_param(self):
        import xmlrpclib
        attempt_id = self._loaded_fixtures[0].id

        packet = xmlrpclib.dumps((), methodname='proceed_to_checkout')

        request = testing.DummyRequest()
        request.db = models.ScopedSession
        request.body = packet
        request.content_length = len(packet)

        response = httpd.proceed_to_checkout(request)

        self.assertEqual(response.content_type, 'text/xml')
        self.assertEqual(response.body, xmlrpclib.dumps((),
                                                        methodresponse=True))
        self.assertEqual(response.content_length, len(response.body))
        self.assertEqual(response.status, '200 OK')
```
