### PR TITLE
Adicionado no checkout.py a capacidade de processar pacotes .zip

### DIFF
--- a/balaio/lib/utils.py
+++ b/balaio/lib/utils.py
@@ -4,6 +4,7 @@ import requests
 import zipfile
 from StringIO import StringIO
 import logging, logging.handlers
+from os.path import isfile, join
 from ConfigParser import SafeConfigParser
 
 from requests.exceptions import Timeout, RequestException
@@ -313,5 +314,16 @@ def get_static_path(path, aid, filename):
     :param aid: aid (article identify)
     :param filename: name of the file
     """
-    return os.path.join(path, aid, os.path.basename(filename))
+    return join(path, aid, os.path.basename(filename))
+
+
+def get_zip_files(path):
+    """
+    Return a list of zip file from directory, it will raise OSError otherwise
+
+    :param path: valid path
+    """
+
+    return [join(path,f) for f in os.listdir(path) if isfile(join(path,f)) and zipfile.is_zipfile(join(path,f))]
+
 


### PR DESCRIPTION
Relacionado com o #312
- Removido temporariamente o multi-processamento, pois a biblioteca paramiko não sabe lidar com esse tipo de arquitetura;
- Adicionado a capacidade de processa um ou mais pacotes por command line;
- Alterado as funções para receber objetos PackageAnalyer
- Foi mantido um path temporário para os arquivos estático até que o ticket #311 seja discutido.
